### PR TITLE
Install golangci-lint from docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,10 +70,15 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
+      - name: Get version
+        id: version
+        run: |
+          ./tools/docker-base-tag.sh Dockerfile mirror.gcr.io/golangci/golangci-lint >> $GITHUB_OUTPUT
+
       - name: Lint Go
         uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6.5.0
         with:
-          version: v1.64.5
+          version: ${{ steps.version.outputs.tag }}
           args: --timeout=10m
 
       - name: Lint Protobuf

--- a/tools/docker-base-tag.sh
+++ b/tools/docker-base-tag.sh
@@ -1,0 +1,34 @@
+#! /usr/bin/env bash
+
+# Check if the correct number of arguments are passed
+if [ $# -lt 2 ]; then
+  echo "Usage: $0 <Dockerfile> <image_name_1> <image_name_2> ... <image_name_n>"
+  exit 1
+fi
+
+# File path to the Dockerfile
+DOCKERFILE=$1
+
+# Shift the first argument to get the image names
+shift
+
+# Check if the Dockerfile exists
+if [ ! -f "$DOCKERFILE" ]; then
+  echo "Error: $DOCKERFILE does not exist."
+  exit 1
+fi
+
+# Loop over the image names provided as arguments
+for image in "$@"; do
+  # Extract the tag of the specific base image from the Dockerfile
+  tag=$(grep -i "^FROM\s\+$image" $DOCKERFILE | \
+    cut -d: -f2 | \
+    cut -d@ -f1)
+
+  if [ -z "$tag" ]; then
+    echo "Image: $image - Tag: Not found" 1>&2
+    exit 1
+  else
+    echo "tag=$tag"
+  fi
+done


### PR DESCRIPTION
- Document the use of `mirror.gcr.io` in `Dockerfile`.
- Change the dev-env to pull `golangci-lint` from a docker image with tag and digest.
- Update CI to use the `golangci-lint` version based on the tag in the `Dockerfile`.
- Simplify user creation for the dev-env.
- Drop the unused `tini` from the dev-env.
- Mark the dev-env workspace as a safe directory in git to avoid vcs info errors in `golangci-lint`.