### PR TITLE
Support collecting functional test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,11 +241,11 @@ jobs:
         run: |
           echo "::group::rpc logs"
           docker compose logs rpc
-          echo "::endgroup"
+          echo "::endgroup::"
 
           echo "::group::postgres logs"
           docker compose logs postgres
-          echo "::endgroup"
+          echo "::endgroup::"
 
   tag:
     name: Tag

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,7 +241,16 @@ jobs:
           down-flags: --volumes --remove-orphans
 
       # TODO: run tests
-      # TODO: collect logs
+
+      - name: Collect logs
+        run: |
+          ::group rpc
+          docker compose logs rpc
+          ::endgroup
+
+          ::group postgres
+          docker compose logs postgres
+          ::endgroup
 
   tag:
     name: Tag

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,19 +218,13 @@ jobs:
         uses: gacts/run-and-post-run@d803f6920adc9a47eeac4cb6c93dbc2e2890c684 # v1.4.2
         with:
           run: |
-            whoami
+            # hack to let container's user create coverage files
             sudo chown 65532:65532 .covdata
 
-            pwd
-            ls -alph
-            ls -alph .covdata || true
-
+            # enable coverage builds
             echo GO_BUILD_ARGS=-cover > .env
           post: |
-            pwd
-            ls -alph
-            ls -alph .covdata || true
-
+            # TODO: publish this somewhere
             go tool covdata percent -i=.covdata
 
       - name: Start
@@ -243,14 +237,15 @@ jobs:
       # TODO: run tests
 
       - name: Collect logs
+        if: always()
         run: |
-          ::group rpc
+          echo "::group::rpc logs"
           docker compose logs rpc
-          ::endgroup
+          echo "::endgroup"
 
-          ::group postgres
+          echo "::group::postgres logs"
           docker compose logs postgres
-          ::endgroup
+          echo "::endgroup"
 
   tag:
     name: Tag

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,14 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Setup coverage
+        uses: gacts/run-and-post-run@d803f6920adc9a47eeac4cb6c93dbc2e2890c684 # v1.4.2
+        with:
+          run: |
+            echo GO_BUILD_ARGS=-cover > .env
+          post: |
+            go tool covdata percent -i=.covdata
+
       - name: Start
         uses: hoverkraft-tech/compose-action@8be2d741e891ac9b8ac20825e6f3904149599925 # v2.2.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,9 @@ jobs:
         uses: gacts/run-and-post-run@d803f6920adc9a47eeac4cb6c93dbc2e2890c684 # v1.4.2
         with:
           run: |
+            whoami
+            chown 65532:65532 .covdata
+
             pwd
             ls -alph
             ls -alph .covdata || true
@@ -238,6 +241,7 @@ jobs:
           down-flags: --volumes --remove-orphans
 
       # TODO: run tests
+      # TODO: collect logs
 
   tag:
     name: Tag

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,7 @@ jobs:
         with:
           run: |
             whoami
-            chown 65532:65532 .covdata
+            sudo chown 65532:65532 .covdata
 
             pwd
             ls -alph

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,8 +218,16 @@ jobs:
         uses: gacts/run-and-post-run@d803f6920adc9a47eeac4cb6c93dbc2e2890c684 # v1.4.2
         with:
           run: |
+            pwd
+            ls -alph
+            ls -alph .covdata || true
+
             echo GO_BUILD_ARGS=-cover > .env
           post: |
+            pwd
+            ls -alph
+            ls -alph .covdata || true
+
             go tool covdata percent -i=.covdata
 
       - name: Start

--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,8 @@ go.work.sum
 # Build oututs
 dist/
 
-# Unit test output
+# Coverage outputs
 cover.html
+.covdata/**
+!.covdata/.gitkeep
+functional.html

--- a/.justfile
+++ b/.justfile
@@ -7,6 +7,7 @@ db_user := "postgres"
 db_pass := "secret"
 export BUILDKIT_PROGRESS := "plain"
 now := shell("date +%s")
+go_module := shell("go list -m")
 
 [private]
 default:
@@ -159,6 +160,16 @@ unit timeout="30s":
     @echo "Total coverage: `go tool cover -func=cover.out | tail -n 1 | awk '{print $3}'`"
     go tool cover -html cover.out -o cover.html
 
+# Summarise functional test coverage.
+functional-cover:
+    go tool covdata textfmt -i=.covdata -o functional.out
+    @echo "Total coverage: `go tool cover -func=cover.out | tail -n 1 | awk '{print $3}'`"
+    go tool cover -html functional.out -o functional.html
+
+# Delete functional test coverage artifacts.
+functional-cover-clean:
+    rm -f .covdata/cov*
+
 # Scan the repository for issues.
 scan: scan-gitleaks scan-trivy scan-zizmor
 
@@ -198,14 +209,23 @@ container-build: container-build-rpc
 # Build the example-rpc container.
 container-build-rpc: (_container-build "example-rpc")
 
+#
+container-build-cover: container-build-cover-rpc
+
+#
+container-build-cover-rpc: (_container-build-cover "example-rpc")
+
 [private]
-_container-build service:
+_container-build-cover service: (_container-build service "-cover")
+
+[private]
+_container-build service go_build_args="":
     SOURCE_DATE_EPOCH=0 docker buildx build \
         --pull \
-        --no-cache \
         --target runtime \
         --build-arg SERVICE={{ service }} \
         --build-arg SOURCE_DATE_EPOCH=0 \
+        --build-arg GO_BUILD_ARGS="{{ go_build_args }}" \
         --tag {{ service }}:{{ now }} \
         --tag {{ service }}:local \
         .

--- a/.justfile
+++ b/.justfile
@@ -7,7 +7,6 @@ db_user := "postgres"
 db_pass := "secret"
 export BUILDKIT_PROGRESS := "plain"
 now := shell("date +%s")
-go_module := shell("go list -m")
 
 [private]
 default:
@@ -204,19 +203,10 @@ db-seed:
         --file ./tools/seed.sql
 
 # Build all containers.
-container-build: container-build-rpc
+container-build go_build_args="": (container-build-rpc go_build_args)
 
 # Build the example-rpc container.
-container-build-rpc: (_container-build "example-rpc")
-
-#
-container-build-cover: container-build-cover-rpc
-
-#
-container-build-cover-rpc: (_container-build-cover "example-rpc")
-
-[private]
-_container-build-cover service: (_container-build service "-cover")
+container-build-rpc go_build_args="": (_container-build "example-rpc" go_build_args)
 
 [private]
 _container-build service go_build_args="":

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,11 @@ WORKDIR /go/src
 
 ARG TARGETOS TARGETARCH
 ARG SOURCE_DATE_EPOCH=0
+ARG GO_BUILD_ARGS
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=bind,target=. \
     CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
-    go build -trimpath -ldflags="-buildid= -s -w" -o /go/bin/ ./cmd/...; \
+    go build ${GO_BUILD_ARGS} -trimpath -ldflags="-buildid= -s -w" -o /go/bin/ ./cmd/...; \
     touch --date=@${SOURCE_DATE_EPOCH} /go/bin/*;
 
 # --------------

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,8 +8,10 @@ services:
       target: runtime
       args:
         SERVICE: example-rpc
+        GO_BUILD_ARGS: ${GO_BUILD_ARGS:-}
     entrypoint: ["/example-rpc"]
     environment:
+      GOCOVERDIR: "/covdata"
       APP_DATABASE_HOSTNAME: "postgres"
       APP_DATABASE_USERNAME: "postgres"
       APP_DATABASE_PASSWORD: "secret"
@@ -21,6 +23,8 @@ services:
       OTEL_GO_X_DEPRECATED_RUNTIME_METRICS: "false"
     ports:
       - "127.0.0.1:5000:5000"
+    volumes:
+      - "./.covdata:/covdata"
     healthcheck:
       test: [ "CMD", "/example-health" ]
       start_period: "30s"

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,38 @@
+# Testing
+
+## Unit testing
+
+### Coverage
+
+## Functional Testing
+
+### Coverage
+
+Functional test coverage is not enabled by default. However, it can be collected by enabling
+coverage profiling in the Development Environment's rpc container build, running the tests and then
+stopping the development environment.
+
+```sh
+# delete any stale artifacts
+just functional-cover-clean
+
+# enable coverage profiling
+echo GO_BUILD_ARGS=-cover > .env
+
+# rebuild the rpc container
+just dev-restart
+
+# execute the functional tests
+# TODO
+
+# shutdown the rpc container to output coverage
+just dev-down
+```
+
+This will produce a number of files in the `.covdata/` directory which can be coverted to a HTML
+report:
+
+```sh
+# output the overall coverage and generate `functional.html`
+just functional-cover
+```


### PR DESCRIPTION
- Add Dockerfile ARG to support additional Go build flags.
- Adjust just recipes to support additional Go build flags.
- Adjust compose.yaml to support additional Go build flags.
- Create and mount a host directory for collecting coverage results from running containers.
- Add just recipes for cleaning and processing functional test coverage outputs.
- Update CI to generate and print functional test coverage.