### PR TITLE
Update to golangci-lint v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
           ./tools/docker-base-tag.sh Dockerfile.dev mirror.gcr.io/golangci/golangci-lint >> $GITHUB_OUTPUT
 
       - name: Lint Go
-        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
+        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:
           version: ${{ steps.version.outputs.tag }}
           args: --timeout=10m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,6 @@
 # https://golangci-lint.run/usage/configuration/
 
+version: "2"
 linters:
   enable:
     - asciicheck
@@ -12,11 +13,9 @@ linters:
     - dogsled
     - dupl
     - durationcheck
-    - errcheck
     - exhaustive
     - fatcontext
     - forcetypeassert
-    - gci
     - gocheckcompilerdirectives
     - gochecknoinits
     - gochecksumtype
@@ -24,15 +23,11 @@ linters:
     - goconst
     - gocritic
     - godot
-    - gofumpt
     - gomoddirectives
     - goprintffuncname
     - gosec
-    - gosimple
-    - govet
     - grouper
     - iface
-    - ineffassign
     - importas
     - intrange
     - makezero
@@ -55,50 +50,70 @@ linters:
     - spancheck
     - sqlclosecheck
     - staticcheck
-    - stylecheck
     - tagliatelle
     - testifylint
     - testpackage
     - thelper
     - unconvert
     - unparam
-    - unused
     - usestdlibvars
     - usetesting
     - wastedassign
     - whitespace
 
-linters-settings:
-  gci:
-    sections:
-      - standard
-      - default
-      - localmodule
-    skip-generated: true
+  settings:
+    gocognit:
+      min-complexity: 15
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - style
+        - performance
+        - experimental
+        - opinionated
+    sloglint:
+      attr-only: true
+      context: all
+      static-msg: true
+      no-raw-keys: true
+      key-naming-case: snake
+      forbidden-keys:
+        - time
+        - level
+        - msg
+        - source
 
-  gocognit:
-    min-complexity: 15
-
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - style
-      - performance
-      - experimental
-      - opinionated
-
-  sloglint:
-    attr-only: true
-    context: "all"
-    static-msg: true
-    no-raw-keys: true
-    key-naming-case: snake
-    forbidden-keys:
-      - time
-      - level
-      - msg
-      - source
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
+
+formatters:
+  enable:
+    - gci
+    - gofumpt
+
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - localmodule
+
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -14,7 +14,7 @@ FROM mirror.gcr.io/golang:1.24-bookworm@sha256:fa1a01d362a7b9df68b021d59a124d28c
 # ------------
 
 FROM ghcr.io/gitleaks/gitleaks:v8.24.2@sha256:b5918eb91b8d2473cec722f066abb4352e4ffdc4ec9f4283ec143aba9ec9ebc4 AS gitleaks
-FROM mirror.gcr.io/golangci/golangci-lint:v1.64.8@sha256:2987913e27f4eca9c8a39129d2c7bc1e74fbcf77f181e01cea607be437aa5cb8 AS golangci-lint
+FROM mirror.gcr.io/golangci/golangci-lint:v2.0.2@sha256:d55581f7797e7a0877a7c3aaa399b01bdc57d2874d6412601a046cc4062cb62e AS golangci-lint
 FROM ghcr.io/aquasecurity/trivy:0.61.0@sha256:6967db29ce5294d054121e94b3cb1262de858af63b4547bb1bade66a4306f2e4 AS trivy
 FROM ghcr.io/woodruffw/zizmor:1.5.2@sha256:f0bbe68825022e3336389e754d4c8a28928246275e9c549251997f25318896f1 AS zizmor
 


### PR DESCRIPTION
- Combines #180 and #184 for using the latest golangci-lint version.
- Migrate config file to v2 structure.