### PR TITLE
Use alternative shell for zizmor entrypoint

### DIFF
--- a/.github/actions/zizmor/entrypoint.sh
+++ b/.github/actions/zizmor/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-cmd=(/app/zizmor $@ ${INPUT_INPUTS[@]})
-echo "Running command: ${cmd[@]}"
-${cmd[@]}
+cmd="/app/zizmor $@ ${INPUT_INPUTS}"
+echo "Running command: ${cmd}"
+${cmd}

--- a/.github/actions/zizmor/entrypoint.sh
+++ b/.github/actions/zizmor/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 cmd=(/app/zizmor $@ ${INPUT_INPUTS[@]})
 echo "Running command: ${cmd[@]}"

--- a/.justfile
+++ b/.justfile
@@ -182,7 +182,18 @@ scan-trivy:
 
 # Scan actions and workflows using Zizmor.
 scan-zizmor:
-    zizmor --persona pedantic .github/actions/*/*.yml .github/workflows/*.yml
+    zizmor --persona pedantic .
+
+[private]
+scan-zizmor-ci:
+    docker buildx build --tag zizmor:local ./.github/actions/zizmor/
+    docker run \
+        --rm \
+        --workdir /github/workspace \
+        -e "INPUT_INPUTS=." \
+        -v ".":"/github/workspace" \
+        zizmor:local \
+        "--persona=pedantic"
 
 # Build all binaries.
 build:

--- a/buf.lock
+++ b/buf.lock
@@ -2,5 +2,5 @@
 version: v2
 deps:
   - name: buf.build/bufbuild/protovalidate
-    commit: 0409229c37804d6187ee0806eb4eebce
-    digest: b5:795db9d3a6e066dc61d99ac651fa7f136171869abe2211ca272dd84aada7bc4583b9508249fa5b61300a5b1fe8b6dbf6edbc088aa0345d1ccb9fff705e3d48e9
+    commit: 8976f5be98c146529b1cc15cd2012b60
+    digest: b5:5d513af91a439d9e78cacac0c9455c7cb885a8737d30405d0b91974fe05276d19c07a876a51a107213a3d01b83ecc912996cdad4cddf7231f91379079cf7488d


### PR DESCRIPTION
Fix for CI failure in #207.

- Remove bash-isms in zizmor entrypoint.sh in favour of POSIX shell syntax.
- Add just recipe for running the zizmor CI action locally (approximately).
- Simplify path(s) in scan-zizmor just recipe to align with CI action.