### PR TITLE
Workaround zizmor dockerfile using wolfi-base

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -3,12 +3,6 @@
 # mirror.gcr.io caches of popular docker hub images, but does not add rate limiting.
 # See https://cloud.google.com/artifact-registry/docs/pull-cached-dockerhub-images.
 
-# -----------
-# Base target
-# -----------
-
-FROM mirror.gcr.io/golang:1.24-bookworm@sha256:00eccd446e023d3cd9566c25a6e6a02b90db3e1e0bbe26a48fc29cd96e800901 AS base
-
 # ------------
 # Dependencies
 # ------------
@@ -16,14 +10,12 @@ FROM mirror.gcr.io/golang:1.24-bookworm@sha256:00eccd446e023d3cd9566c25a6e6a02b9
 FROM ghcr.io/gitleaks/gitleaks:v8.24.3@sha256:e1b35e12a8c6fa8901f060459cfb6b2fc4c484d3afbe3b029733a3bbfab07055 AS gitleaks
 FROM mirror.gcr.io/golangci/golangci-lint:v2.1.2@sha256:86f65772316ad8baa4bd5bb1363640fa4054a9df0ae8150b1eef893c4751533c AS golangci-lint
 FROM ghcr.io/aquasecurity/trivy:0.61.1@sha256:91bcccab7cb503127b0d792db7c652c4e556c9ff30eeb0908b6ae1980d7727ad AS trivy
-FROM ghcr.io/woodruffw/zizmor:1.5.2@sha256:f0bbe68825022e3336389e754d4c8a28928246275e9c549251997f25318896f1 AS zizmor
-
 
 # -------------
 # Devenv target
 # -------------
 
-FROM base AS dev
+FROM mirror.gcr.io/golang:1.24-bookworm@sha256:00eccd446e023d3cd9566c25a6e6a02b90db3e1e0bbe26a48fc29cd96e800901 AS dev
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
@@ -31,6 +23,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update; \
     apt-get install -y --no-install-recommends \
         postgresql-client \
+        python3-pip \
     ;
 
 RUN set -eux; \
@@ -42,6 +35,7 @@ RUN set -eux; \
 
 ENV GOPATH=''
 USER dev
+
 RUN set -eux; \
     echo "export PATH=$PATH:/usr/local/go/bin:$HOME/go/bin" >> /home/dev/.bashrc; \
     mkdir -p /home/dev/ws; \
@@ -50,8 +44,13 @@ RUN set -eux; \
 COPY --from=gitleaks /usr/bin/gitleaks /usr/bin/gitleaks
 COPY --from=golangci-lint /usr/bin/golangci-lint /usr/bin/golangci-lint
 COPY --from=trivy /usr/local/bin/trivy /usr/bin/trivy
-COPY --from=zizmor /app/zizmor /usr/bin/zizmor
 
+ARG ZIZMOR_VERSION=1.6.0
+# TODO: add cache mounts?
+RUN set -eux; \
+    pip3 install --user --break-system-packages zizmor==${ZIZMOR_VERSION};
+
+# TODO: add cache mounts
 RUN set -eux; \
     go install github.com/bwplotka/bingo@latest;
 


### PR DESCRIPTION
The zizmor container changed to use wolfi-base as it's base image, installing zizmor via apk. While this removed bash (see #219), the CI entrypoint script was not too hard to adapt.

It did however affect the dev-env. The dev-env uses Debian 12, which offers a relatively stable set of dependencies. Wolfi (and it's maintainers at Chainguard) meanwhile prioritises security over stability, and so will regularly update OS dependencies. This includes glibc.

The problem is that zizmor is not statically linked by whatever builds the zizmor apk, and so depends on glibc 2.39. Meanwhile, debian 12 comes with 2.36. Glibc is often backwards compatible, but never forwards compatible, and so the rust runtime aborts when executing zizmor. While we could wait for debian 13 it just moves the problem down the road until wolfi updates again.

To workaround the issue, I've swapped the install of zizmor to pip. This opens up another can of worms in how debian 12 works with pip - a cursory glance suggests it mostly doesn't work and python3-pip is likely useless now. but with a little brute force, it can be used to install zizmor. pipx seems to be a better dependency manager for this, but I didn't investigate much further, especially as zizmor doesn't appear to have any python dependencies.

This does introduce a potential drift between the dev-env and CI. this can possibly be resolved by doing the opposite of what golangci-lint does, i.e. copy the version from the CI dockerfile and pass it as a build arg. But that can come later - on the off chance better ideas materialise such as unifying the install method for both workflows.