### PR TITLE
Delete old packages on nightly schedule

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,22 @@
+name: Cleanup
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+permissions: {}
+
+jobs:
+  packages:
+    name: Packages
+    permissions:
+      packages: write
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Cleanup old packages
+        uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
+        with:
+          package-name: "sandbox/example-rpc"
+          package-type: "container"
+          min-versions-to-keep: 5


### PR DESCRIPTION
Delete old containers each night to reduce space usage. And as this is a toy project, there's little gain from retaining the artifacts anyway.

Fixes #186.