### PR TITLE
Align gRPC dashboard's internal errors with ConnectRPC dashboard

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -55,7 +55,6 @@ services:
       start_interval: "1s"
     restart: always
 
-
   jaeger:
     image: "mirror.gcr.io/jaegertracing/jaeger:2.5.0"
     pull_policy: "always"
@@ -67,10 +66,8 @@ services:
       start_interval: "1s"
     restart: always
 
-  # TODO: use plain prometheus?
-  #       avoids need for grafana plugin, but modifies meter provider to enable scraping
   victoria-metrics:
-    image: "mirror.gcr.io/victoriametrics/victoria-metrics:latest" # TODO: pick tag
+    image: "mirror.gcr.io/victoriametrics/victoria-metrics:v1.116.0"
     pull_policy: "always"
     ports:
       - "127.0.0.1:8428:8428"
@@ -81,7 +78,7 @@ services:
     restart: always
 
   victoria-logs:
-    image: "mirror.gcr.io/victoriametrics/victoria-logs:latest" # TODO: pick tag
+    image: "mirror.gcr.io/victoriametrics/victoria-logs:v1.21.0-victorialogs"
     pull_policy: "always"
     ports:
       - "127.0.0.1:9428:9428"
@@ -92,7 +89,7 @@ services:
     restart: always
 
   grafana:
-    image: "mirror.gcr.io/grafana/grafana:latest" # TODO: pick tag
+    image: "mirror.gcr.io/grafana/grafana:11.6.1"
     pull_policy: "always"
     environment:
       GF_AUTH_ANONYMOUS_ENABLED: "true"

--- a/config/dashboards/grpc.json
+++ b/config/dashboards/grpc.json
@@ -18,7 +18,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 1,
+  "id": 4,
   "links": [],
   "panels": [
     {
@@ -52,10 +52,10 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "This dashboard provides visualisations for 3 of the 4 golden signals: Errors,\nLatency and Traffic.\n\nIt aims to track compliance with the following [SLOs][1]:\n\n* 99% of requests must be served within 100ms.\n* 99% of requests must result in a success response.\n\nThe following [status codes][2] are considered to be error responses.\n\n| Status Code      | ID |\n| ---------------- | -- |\n| Unknown          | 2  |\n| DeadlineExceeded | 4  |\n| Internal         | 13 |\n| Unavailable      | 14 |\n\n[1]: https://sre.google/sre-book/service-level-objectives/\n[2]: https://grpc.io/docs/guides/status-codes/",
+        "content": "This dashboard provides visualisations for 3 of the 4 golden signals: Errors,\nLatency and Traffic.\n\nIt aims to track compliance with the following [SLOs][1]:\n\n* 99% of requests must be served within 100ms.\n* 99% of requests must result in a success response.\n\nThe following [status codes][2] are considered to be error responses.\n\n- Unknown (2)\n- DeadlineExceeded (4)\n- Unimplemented (12)\n- Internal (13)\n- Unavailable (14)\n- Data Loss (15)\n\n[1]: https://sre.google/sre-book/service-level-objectives/\n[2]: https://grpc.io/docs/guides/status-codes/",
         "mode": "markdown"
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "11.6.1",
       "title": "",
       "type": "text"
     },
@@ -91,8 +91,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -128,7 +127,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "11.6.1",
       "targets": [
         {
           "datasource": {
@@ -165,8 +164,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -202,11 +200,11 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "11.6.1",
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum(increase(rpc.server.duration_count{rpc.system=\"grpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.grpc.status_code=~\"2|4|13|14\"}[$__rate_interval])) / sum(increase(rpc.server.duration_count{rpc.system=\"grpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\"}[$__rate_interval]))",
+          "expr": "sum(increase(rpc.server.duration_count{rpc.system=\"grpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.grpc.status_code=~\"2|4|12|13|14|15\"}[$__rate_interval])) / sum(increase(rpc.server.duration_count{rpc.system=\"grpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\"}[$__rate_interval]))",
           "legendFormat": "Requests",
           "range": true,
           "refId": "A"
@@ -387,8 +385,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -416,7 +413,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "11.6.1",
       "targets": [
         {
           "datasource": {
@@ -485,8 +482,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -518,11 +514,11 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "11.6.1",
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by(service.name,rpc.service,rpc.method) (increase(rpc.server.duration_count{rpc.system=\"grpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.grpc.status_code=~\"2|4|13|14\"}[$__rate_interval])) / sum by(service.name,rpc.service,rpc.method) (increase(rpc.server.duration_count{rpc.system=\"grpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\"}[$__rate_interval]))",
+          "expr": "sum by(service.name,rpc.service,rpc.method) (increase(rpc.server.duration_count{rpc.system=\"grpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.grpc.status_code=~\"2|4|12|13|14|15\"}[$__rate_interval])) / sum by(service.name,rpc.service,rpc.method) (increase(rpc.server.duration_count{rpc.system=\"grpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\"}[$__rate_interval]))",
           "legendFormat": "{{service.name}} {{rpc.service}}/{{rpc.method}}",
           "range": true,
           "refId": "A"
@@ -681,8 +677,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -718,12 +713,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "11.6.1",
       "targets": [
         {
           "editorMode": "code",
           "exemplar": false,
-          "expr": "histogram_quantile(0.5, sum(increase(rpc.server.duration_bucket{rpc.system=\"grpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.grpc.status_code!~\"2|4|13|14\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.5, sum(increase(rpc.server.duration_bucket{rpc.system=\"grpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.grpc.status_code!~\"2|4|12|13|14|15\"}[$__rate_interval])) by (le))",
           "format": "time_series",
           "instant": false,
           "legendFormat": "p50",
@@ -751,8 +746,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -788,12 +782,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "11.6.1",
       "targets": [
         {
           "editorMode": "code",
           "exemplar": false,
-          "expr": "histogram_quantile(0.5, sum(increase(rpc.server.duration_bucket{rpc.system=\"grpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.grpc.status_code=~\"2|4|13|14\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.5, sum(increase(rpc.server.duration_bucket{rpc.system=\"grpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.grpc.status_code=~\"2|4|12|13|14|15\"}[$__rate_interval])) by (le))",
           "format": "time_series",
           "instant": false,
           "legendFormat": "p50",
@@ -821,8 +815,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -858,12 +851,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "11.6.1",
       "targets": [
         {
           "editorMode": "code",
           "exemplar": false,
-          "expr": "histogram_quantile(0.9, sum(increase(rpc.server.duration_bucket{rpc.system=\"grpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.grpc.status_code!~\"2|4|13|14\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.9, sum(increase(rpc.server.duration_bucket{rpc.system=\"grpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.grpc.status_code!~\"2|4|12|13|14|15\"}[$__rate_interval])) by (le))",
           "format": "time_series",
           "instant": false,
           "legendFormat": "p50",
@@ -891,8 +884,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -928,12 +920,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "11.6.1",
       "targets": [
         {
           "editorMode": "code",
           "exemplar": false,
-          "expr": "histogram_quantile(0.9, sum(increase(rpc.server.duration_bucket{rpc.system=\"grpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.grpc.status_code=~\"2|4|13|14\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.9, sum(increase(rpc.server.duration_bucket{rpc.system=\"grpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.grpc.status_code=~\"2|4|12|13|14|15\"}[$__rate_interval])) by (le))",
           "format": "time_series",
           "instant": false,
           "legendFormat": "p50",
@@ -961,8 +953,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -998,12 +989,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "11.6.1",
       "targets": [
         {
           "editorMode": "code",
           "exemplar": false,
-          "expr": "histogram_quantile(0.99, sum(increase(rpc.server.duration_bucket{rpc.system=\"grpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.grpc.status_code!~\"2|4|13|14\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(increase(rpc.server.duration_bucket{rpc.system=\"grpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.grpc.status_code!~\"2|4|12|13|14|15\"}[$__rate_interval])) by (le))",
           "format": "time_series",
           "instant": false,
           "legendFormat": "p50",
@@ -1031,8 +1022,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1068,12 +1058,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "11.6.1",
       "targets": [
         {
           "editorMode": "code",
           "exemplar": false,
-          "expr": "histogram_quantile(0.99, sum(increase(rpc.server.duration_bucket{rpc.system=\"grpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.grpc.status_code=~\"2|4|13|14\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(increase(rpc.server.duration_bucket{rpc.system=\"grpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.grpc.status_code=~\"2|4|12|13|14|15\"}[$__rate_interval])) by (le))",
           "format": "time_series",
           "instant": false,
           "legendFormat": "p50",
@@ -1133,8 +1123,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1166,7 +1155,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "11.6.1",
       "targets": [
         {
           "datasource": {
@@ -1256,8 +1245,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1289,7 +1277,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "11.6.1",
       "targets": [
         {
           "datasource": {
@@ -1297,7 +1285,7 @@
             "uid": "victoriametrics"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.5, sum(increase(rpc.server.duration_bucket{rpc.system=\"grpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.grpc.status_code!~\"2|4|13|14\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.5, sum(increase(rpc.server.duration_bucket{rpc.system=\"grpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.grpc.status_code!~\"2|4|12|13|14|15\"}[$__rate_interval])) by (le))",
           "legendFormat": "p50",
           "range": true,
           "refId": "A"
@@ -1308,7 +1296,7 @@
             "uid": "victoriametrics"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.9, sum(increase(rpc.server.duration_bucket{rpc.system=\"grpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.grpc.status_code!~\"2|4|13|14\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.9, sum(increase(rpc.server.duration_bucket{rpc.system=\"grpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.grpc.status_code!~\"2|4|12|13|14|15\"}[$__rate_interval])) by (le))",
           "hide": false,
           "legendFormat": "p90",
           "range": true,
@@ -1320,7 +1308,7 @@
             "uid": "victoriametrics"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(increase(rpc.server.duration_bucket{rpc.system=\"grpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.grpc.status_code!~\"2|4|13|14\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(increase(rpc.server.duration_bucket{rpc.system=\"grpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.grpc.status_code!~\"2|4|12|13|14|15\"}[$__rate_interval])) by (le))",
           "hide": false,
           "legendFormat": "p99",
           "range": true,
@@ -1379,8 +1367,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1412,7 +1399,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "11.6.1",
       "targets": [
         {
           "datasource": {
@@ -1420,7 +1407,7 @@
             "uid": "victoriametrics"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.5, sum(increase(rpc.server.duration_bucket{rpc.system=\"grpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.grpc.status_code=~\"2|4|13|14\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.5, sum(increase(rpc.server.duration_bucket{rpc.system=\"grpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.grpc.status_code=~\"2|4|12|13|14|15\"}[$__rate_interval])) by (le))",
           "legendFormat": "p50",
           "range": true,
           "refId": "A"
@@ -1431,7 +1418,7 @@
             "uid": "victoriametrics"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.9, sum(increase(rpc.server.duration_bucket{rpc.system=\"grpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.grpc.status_code=~\"2|4|13|14\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.9, sum(increase(rpc.server.duration_bucket{rpc.system=\"grpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.grpc.status_code=~\"2|4|12|13|14|15\"}[$__rate_interval])) by (le))",
           "hide": false,
           "legendFormat": "p90",
           "range": true,
@@ -1443,7 +1430,7 @@
             "uid": "victoriametrics"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(increase(rpc.server.duration_bucket{rpc.system=\"grpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.grpc.status_code=~\"2|4|13|14\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(increase(rpc.server.duration_bucket{rpc.system=\"grpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.grpc.status_code=~\"2|4|12|13|14|15\"}[$__rate_interval])) by (le))",
           "hide": false,
           "legendFormat": "p99",
           "range": true,
@@ -1516,7 +1503,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "11.6.1",
       "targets": [
         {
           "editorMode": "code",
@@ -1698,8 +1685,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           }
@@ -1726,7 +1712,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "11.6.1",
       "targets": [
         {
           "editorMode": "code",
@@ -1787,8 +1773,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1819,7 +1804,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "11.6.1",
       "targets": [
         {
           "editorMode": "code",
@@ -1957,7 +1942,7 @@
   ],
   "preload": false,
   "refresh": "1m",
-  "schemaVersion": 40,
+  "schemaVersion": 41,
   "tags": [],
   "templating": {
     "list": [
@@ -2031,6 +2016,5 @@
   "timezone": "browser",
   "title": "gRPC",
   "uid": "aeaqszf1dscn4b",
-  "version": 1,
-  "weekStart": ""
+  "version": 1
 }


### PR DESCRIPTION
Adds Unimplemented and Data Loss to the gRPC status codes considered to be an internal error in the gRPC dashboard. This aligns with the ConnectRPC dashboard, as well as the behaviour in the otelconnect interceptor which marks the span status as error for 6 status codes.

Also selects specific tags for images in the development environment, resolving a handful of TODOs.

Fixes #196.