### PR TITLE
Install zizmor using pipx

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -23,7 +23,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update; \
     apt-get install -y --no-install-recommends \
         postgresql-client \
-        python3-pip \
+        pipx \
     ;
 
 RUN set -eux; \
@@ -38,6 +38,7 @@ USER dev
 
 RUN set -eux; \
     echo "export PATH=$PATH:/usr/local/go/bin:$HOME/go/bin" >> /home/dev/.bashrc; \
+    pipx ensurepath; \
     mkdir -p /home/dev/ws; \
     git config --global --add safe.directory /home/dev/ws;
 
@@ -48,7 +49,7 @@ COPY --from=trivy /usr/local/bin/trivy /usr/bin/trivy
 ARG ZIZMOR_VERSION=1.6.0
 # TODO: add cache mounts?
 RUN set -eux; \
-    pip3 install --user --break-system-packages zizmor==${ZIZMOR_VERSION};
+    pipx install zizmor==${ZIZMOR_VERSION};
 
 # TODO: add cache mounts
 RUN set -eux; \


### PR DESCRIPTION
Installs `pipx` to install `zizmor`, avoiding the need to use `--break-system-packages` when running `pip`.