### PR TITLE
Add descriptions to dashboard panels

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -20,6 +20,7 @@ services:
       APP_DATABASE_SSLMODE: "disable"
       APP_LOGGING_LEVEL: "debug"
       APP_RPCSERVER_HOST: "0.0.0.0"
+      APP_RPCSERVER_ENABLEPPROF: "true"
       APP_METERPROVIDER_ENDPOINT: "http://victoria-metrics:8428/opentelemetry/v1/metrics"
       APP_TRACERPROVIDER_ENDPOINT: "http://jaeger:4318"
       APP_LOGGERPROVIDER_ENDPOINT: "http://victoria-logs:9428/insert/opentelemetry/v1/logs"

--- a/config/dashboards/connectrpc.json
+++ b/config/dashboards/connectrpc.json
@@ -18,7 +18,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 3,
+  "id": 4,
   "links": [],
   "panels": [
     {
@@ -55,7 +55,7 @@
         "content": "This dashboard provides visualisations for 3 of the 4 golden signals: Errors,\nLatency and Traffic.\n\nIt aims to track compliance with the following [SLOs][1]:\n\n* 99% of requests must be served within 100ms.\n* 99% of requests must result in a success response.\n\nThe following [error codes][2] are classed as internal errors included in error response calculations.\n\n- `unknown`\n- `deadline_exceeded`\n- `unimplemented`\n- `internal`\n- `unavailable`\n- `data_loss`\n\n[1]: https://sre.google/sre-book/service-level-objectives/\n[2]: https://connectrpc.com/docs/protocol#error-codes",
         "mode": "markdown"
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "12.0.0",
       "title": "",
       "type": "text"
     },
@@ -77,6 +77,7 @@
         "type": "victoriametrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The percentage of requests that exceeded the latency threshold across the current time range.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -91,8 +92,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -128,7 +128,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "datasource": {
@@ -151,6 +151,7 @@
         "type": "victoriametrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The percentage of requests that resulted in error responses across the current time range.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -165,8 +166,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -202,7 +202,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "editorMode": "code",
@@ -220,6 +220,7 @@
         "type": "victoriametrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The percentage of requests that exceeded the latency threshold.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -266,8 +267,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -295,7 +295,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "datasource": {
@@ -318,6 +318,7 @@
         "type": "victoriametrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The percentage of requests that resulted in error responses.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -364,8 +365,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -397,7 +397,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "editorMode": "code",
@@ -428,19 +428,20 @@
         "type": "victoriametrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The P99 latency for success responses across the current time range.",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
           "mappings": [],
+          "min": 0,
           "noValue": "N/A",
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -458,7 +459,7 @@
         "x": 0,
         "y": 21
       },
-      "id": 5,
+      "id": 10,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
@@ -476,12 +477,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "editorMode": "code",
           "exemplar": false,
-          "expr": "histogram_quantile(0.5, sum(increase(rpc.server.duration_bucket{rpc.system=\"connect_rpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.connect_rpc.error_code!~\"unknown|deadline_exceeded|unimplemented|internal|unavailable|data_loss\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(increase(rpc.server.duration_bucket{rpc.system=\"connect_rpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.connect_rpc.error_code!~\"unknown|deadline_exceeded|unimplemented|internal|unavailable|data_loss\"}[$__rate_interval])) by (le))",
           "format": "time_series",
           "instant": false,
           "legendFormat": "p50",
@@ -489,7 +490,7 @@
           "refId": "A"
         }
       ],
-      "title": "P50 Average (Success)",
+      "title": "P99 Average (Success)",
       "type": "stat"
     },
     {
@@ -497,6 +498,7 @@
         "type": "victoriametrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The P99 latency for error responses across the current time range.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -509,8 +511,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -528,7 +529,7 @@
         "x": 4,
         "y": 21
       },
-      "id": 6,
+      "id": 9,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
@@ -546,12 +547,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "editorMode": "code",
           "exemplar": false,
-          "expr": "histogram_quantile(0.5, sum(increase(rpc.server.duration_bucket{rpc.system=\"connect_rpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.connect_rpc.error_code=~\"unknown|deadline_exceeded|unimplemented|internal|unavailable|data_loss\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(increase(rpc.server.duration_bucket{rpc.system=\"connect_rpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.connect_rpc.error_code=~\"unknown|deadline_exceeded|unimplemented|internal|unavailable|data_loss\"}[$__rate_interval])) by (le))",
           "format": "time_series",
           "instant": false,
           "legendFormat": "p50",
@@ -559,7 +560,7 @@
           "refId": "A"
         }
       ],
-      "title": "P50 Average (Error)",
+      "title": "P99 Average (Error)",
       "type": "stat"
     },
     {
@@ -567,6 +568,7 @@
         "type": "victoriametrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The P90 latency for success responses across the current time range.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -579,8 +581,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -616,7 +617,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "editorMode": "code",
@@ -637,6 +638,7 @@
         "type": "victoriametrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The P90 latency for error responses across the current time range.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -649,8 +651,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -686,7 +687,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "editorMode": "code",
@@ -707,20 +708,19 @@
         "type": "victoriametrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The P50 latency for success responses across the current time range.",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
           "mappings": [],
-          "min": 0,
           "noValue": "N/A",
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -738,7 +738,7 @@
         "x": 16,
         "y": 21
       },
-      "id": 10,
+      "id": 5,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
@@ -756,12 +756,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "editorMode": "code",
           "exemplar": false,
-          "expr": "histogram_quantile(0.99, sum(increase(rpc.server.duration_bucket{rpc.system=\"connect_rpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.connect_rpc.error_code!~\"unknown|deadline_exceeded|unimplemented|internal|unavailable|data_loss\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.5, sum(increase(rpc.server.duration_bucket{rpc.system=\"connect_rpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.connect_rpc.error_code!~\"unknown|deadline_exceeded|unimplemented|internal|unavailable|data_loss\"}[$__rate_interval])) by (le))",
           "format": "time_series",
           "instant": false,
           "legendFormat": "p50",
@@ -769,7 +769,7 @@
           "refId": "A"
         }
       ],
-      "title": "P99 Average (Success)",
+      "title": "P50 Average (Success)",
       "type": "stat"
     },
     {
@@ -777,6 +777,7 @@
         "type": "victoriametrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The P50 latency for error responses across the current time range.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -789,8 +790,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -808,7 +808,7 @@
         "x": 20,
         "y": 21
       },
-      "id": 9,
+      "id": 6,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
@@ -826,12 +826,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "editorMode": "code",
           "exemplar": false,
-          "expr": "histogram_quantile(0.99, sum(increase(rpc.server.duration_bucket{rpc.system=\"connect_rpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.connect_rpc.error_code=~\"unknown|deadline_exceeded|unimplemented|internal|unavailable|data_loss\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.5, sum(increase(rpc.server.duration_bucket{rpc.system=\"connect_rpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.connect_rpc.error_code=~\"unknown|deadline_exceeded|unimplemented|internal|unavailable|data_loss\"}[$__rate_interval])) by (le))",
           "format": "time_series",
           "instant": false,
           "legendFormat": "p50",
@@ -839,7 +839,7 @@
           "refId": "A"
         }
       ],
-      "title": "P99 Average (Error)",
+      "title": "P50 Average (Error)",
       "type": "stat"
     },
     {
@@ -847,6 +847,7 @@
         "type": "victoriametrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The latency for all responses.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -891,8 +892,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -924,7 +924,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "datasource": {
@@ -970,6 +970,7 @@
         "type": "victoriametrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The latency for success responses.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1014,8 +1015,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1047,7 +1047,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "datasource": {
@@ -1093,6 +1093,7 @@
         "type": "victoriametrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "the latency for error responses.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1137,8 +1138,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1170,7 +1170,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "datasource": {
@@ -1229,6 +1229,7 @@
         "type": "victoriametrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "Total responses by error code for the current time range.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1258,12 +1259,15 @@
         "legend": {
           "displayMode": "table",
           "placement": "right",
-          "showLegend": true
+          "showLegend": true,
+          "values": [
+            "percent"
+          ]
         },
         "pieType": "donut",
         "reduceOptions": {
           "calcs": [
-            "mean"
+            "sum"
           ],
           "fields": "",
           "values": false
@@ -1274,7 +1278,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "editorMode": "code",
@@ -1301,6 +1305,7 @@
         "type": "victoriametrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The number of responses.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1344,8 +1349,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           }
@@ -1372,7 +1376,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "editorMode": "code",
@@ -1390,6 +1394,7 @@
         "type": "victoriametrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The number of responses by error code.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1453,8 +1458,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1485,7 +1489,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "editorMode": "code",
@@ -1511,7 +1515,7 @@
   ],
   "preload": false,
   "refresh": "1m",
-  "schemaVersion": 40,
+  "schemaVersion": 41,
   "tags": [],
   "templating": {
     "list": [
@@ -1521,6 +1525,7 @@
           "value": "$__all"
         },
         "definition": "label_values(rpc.server.duration_bucket{rpc.system=\"connect_rpc\"},service.name)",
+        "description": "Filter panels by service name.",
         "includeAll": true,
         "label": "Service Name",
         "name": "service_name",
@@ -1541,6 +1546,7 @@
           "value": "$__all"
         },
         "definition": "label_values(rpc.server.duration_bucket{rpc.system=\"connect_rpc\",service.name=~\"$service_name\"},rpc.service)",
+        "description": "Filter panels by RPC service.",
         "includeAll": true,
         "label": "RPC Service",
         "name": "rpc_service",
@@ -1561,6 +1567,7 @@
           "value": "$__all"
         },
         "definition": "label_values(rpc.server.duration_bucket{rpc.system=\"connect_rpc\",service.name=~\"$service_name\", rpc.service=~\"$rpc_service\"},rpc.method)",
+        "description": "Filter panels by RPC method.",
         "includeAll": true,
         "label": "RPC Method",
         "name": "rpc_method",
@@ -1585,6 +1592,5 @@
   "timezone": "browser",
   "title": "ConnectRPC",
   "uid": "decj5877wc4xse",
-  "version": 1,
-  "weekStart": ""
+  "version": 1
 }

--- a/config/dashboards/database.json
+++ b/config/dashboards/database.json
@@ -39,6 +39,7 @@
         "type": "victoriametrics-metrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The P99 latency for success responses, averaged across the current time range.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -50,8 +51,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -83,7 +83,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "editorMode": "code",
@@ -101,6 +101,7 @@
         "type": "victoriametrics-metrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The P99 latency for error responses, averaged across the current time range.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -112,8 +113,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -145,7 +145,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "editorMode": "code",
@@ -163,6 +163,7 @@
         "type": "victoriametrics-metrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The P90 latency for success responses, averaged across the current time range.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -174,8 +175,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -207,7 +207,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "datasource": {
@@ -230,6 +230,7 @@
         "type": "victoriametrics-metrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The P90 latency for error responses, averaged across the current time range.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -241,8 +242,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -274,7 +274,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "datasource": {
@@ -297,6 +297,7 @@
         "type": "victoriametrics-metrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The P50 latency for success responses, averaged across the current time range.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -308,8 +309,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -341,7 +341,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "datasource": {
@@ -364,6 +364,7 @@
         "type": "victoriametrics-metrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The P50 latency for error database responses, averaged across the current time range.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -375,8 +376,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -408,7 +408,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "datasource": {
@@ -431,6 +431,7 @@
         "type": "victoriametrics-metrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "Latency for all responses over time.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -474,8 +475,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -507,7 +507,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "editorMode": "code",
@@ -549,6 +549,7 @@
         "type": "victoriametrics-metrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "Latency for success responses over time.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -592,8 +593,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -625,7 +625,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "editorMode": "code",
@@ -667,6 +667,7 @@
         "type": "victoriametrics-metrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "Latency for error responses over time.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -710,8 +711,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -743,7 +743,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "editorMode": "code",
@@ -798,6 +798,7 @@
         "type": "victoriametrics-metrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "Total count of each method and status combination across the current time range.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -826,12 +827,15 @@
         "legend": {
           "displayMode": "list",
           "placement": "right",
-          "showLegend": true
+          "showLegend": true,
+          "values": [
+            "percent"
+          ]
         },
         "pieType": "donut",
         "reduceOptions": {
           "calcs": [
-            "mean"
+            "sum"
           ],
           "fields": "",
           "values": false
@@ -842,7 +846,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "editorMode": "code",
@@ -852,7 +856,7 @@
           "refId": "A"
         }
       ],
-      "title": "Average",
+      "title": "Total",
       "type": "piechart"
     },
     {
@@ -860,6 +864,7 @@
         "type": "victoriametrics-metrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "Number of each method and status combination over time.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -903,8 +908,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -935,7 +939,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "editorMode": "code",
@@ -966,6 +970,7 @@
         "type": "victoriametrics-metrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The current number of open connections.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -976,8 +981,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           }
@@ -1008,7 +1012,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "datasource": {
@@ -1046,6 +1050,7 @@
         "type": "victoriametrics-metrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The current number of connections being waited for.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1056,8 +1061,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1092,7 +1096,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "editorMode": "code",
@@ -1110,6 +1114,7 @@
         "type": "victoriametrics-metrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The current number of closed connections.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1120,8 +1125,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           }
@@ -1152,7 +1156,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "editorMode": "code",
@@ -1194,6 +1198,7 @@
         "type": "victoriametrics-metrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The number of open connections over time.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1237,8 +1242,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1269,7 +1273,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "datasource": {
@@ -1307,6 +1311,7 @@
         "type": "victoriametrics-metrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The number of connections being waited for over time.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1350,8 +1355,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1382,7 +1386,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "editorMode": "code",
@@ -1400,6 +1404,7 @@
         "type": "victoriametrics-metrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The number of closed connections over time.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1443,8 +1448,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1475,7 +1479,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "editorMode": "code",
@@ -1515,7 +1519,7 @@
   ],
   "preload": false,
   "refresh": "1m",
-  "schemaVersion": 40,
+  "schemaVersion": 41,
   "tags": [],
   "templating": {
     "list": [
@@ -1526,6 +1530,7 @@
           "value": "$__all"
         },
         "definition": "label_values(db.sql.connection.max_open,service.name)",
+        "description": "Filter all panels by service.",
         "includeAll": true,
         "label": "Service Name",
         "name": "service_name",
@@ -1547,6 +1552,7 @@
           "value": "$__all"
         },
         "definition": "label_values(db.sql.latency_bucket{service.name=\"$service_name\"},method)",
+        "description": "Filter latency and traffic panels by method.",
         "includeAll": true,
         "label": "Method",
         "name": "method",
@@ -1568,6 +1574,7 @@
           "value": "$__all"
         },
         "definition": "label_values(db.sql.latency_bucket{service.name=\"$service_name\"},status)",
+        "description": "Filter traffic panels by status.",
         "includeAll": true,
         "label": "Status",
         "name": "status",
@@ -1592,6 +1599,5 @@
   "timezone": "browser",
   "title": "Database",
   "uid": "eef5wem86i874c",
-  "version": 1,
-  "weekStart": ""
+  "version": 1
 }

--- a/config/dashboards/go_runtime.json
+++ b/config/dashboards/go_runtime.json
@@ -110,8 +110,8 @@
             "uid": "victoriametrics"
           },
           "editorMode": "code",
-          "expr": "avg by(service.name) (go.goroutine.count{service.name=~\"$service_name\"})",
-          "legendFormat": "{{service.name}} (goroutines)",
+          "expr": "avg by(service.name,service.instance.id) (go.goroutine.count{service.name=~\"$service_name\",service.instance.id=~\"$service_instance_id\"})",
+          "legendFormat": "{{service.name}} goroutines ({{service.instance.id}}",
           "range": true,
           "refId": "A"
         },
@@ -121,9 +121,9 @@
             "uid": "victoriametrics"
           },
           "editorMode": "code",
-          "expr": "avg by(service.name) (go.processor.limit{service.name=~\"$service_name\"})",
+          "expr": "avg by(service.name,service.instance.id) (go.processor.limit{service.name=~\"$service_name\",service.instance.id=~\"$service_instance_id\"})",
           "hide": false,
-          "legendFormat": "{{service.name}} (processor limit)",
+          "legendFormat": "{{service.name}} processor limit ({{service.instance.id}})",
           "range": true,
           "refId": "B"
         }
@@ -136,7 +136,7 @@
         "type": "victoriametrics-datasource",
         "uid": "victoriametrics"
       },
-      "description": "The memory allocated, averaged across all instances of a service.",
+      "description": "The memory used, averaged across all instances of a service.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -215,39 +215,19 @@
       "pluginVersion": "12.0.0",
       "targets": [
         {
-          "editorMode": "code",
-          "expr": "avg by (service.name) (go.memory.allocated{service.name=~\"$service_name\"})",
-          "hide": false,
-          "legendFormat": "{{service.name}} (allocated)",
-          "range": true,
-          "refId": "A"
-        },
-        {
           "datasource": {
             "type": "victoriametrics-datasource",
             "uid": "victoriametrics"
           },
           "editorMode": "code",
-          "expr": "avg by(service.name) (go.memory.used{service.name=~\"$service_name\",go.memory.type=\"stack\"})",
+          "expr": "avg by(service.name,service.instance.id,go.memory.type) (go.memory.used{service.name=~\"$service_name\",service.instance.id=~\"$service_instance_id\"})",
           "hide": false,
-          "legendFormat": "{{service.name}} (stack)",
+          "legendFormat": "{{service.name}} {{go.memory.type}} ({{service.instance.id}})",
           "range": true,
           "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "victoriametrics-datasource",
-            "uid": "victoriametrics"
-          },
-          "editorMode": "code",
-          "expr": "avg by(service.name) (go.memory.used{service.name=~\"$service_name\",go.memory.type=\"other\"})",
-          "hide": false,
-          "legendFormat": "{{service.name}} (other)",
-          "range": true,
-          "refId": "C"
         }
       ],
-      "title": "Memory",
+      "title": "Memory Usage",
       "type": "timeseries"
     }
   ],
@@ -257,12 +237,14 @@
   "templating": {
     "list": [
       {
-        "allValue": ".*",
+        "allValue": "",
+        "allowCustomValue": false,
         "current": {
           "text": "All",
           "value": "$__all"
         },
         "definition": "label_values(go.goroutine.count,service.name)",
+        "description": "Filter by service name",
         "includeAll": true,
         "label": "Service Name",
         "name": "service_name",
@@ -274,6 +256,28 @@
         },
         "refresh": 1,
         "regex": "",
+        "type": "query"
+      },
+      {
+        "allowCustomValue": false,
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "definition": "label_values(go.goroutine.count{service.name=\"$service_name\"},service.instance.id)",
+        "description": "Filter by service instance",
+        "includeAll": true,
+        "label": "Service Instance",
+        "name": "service_instance_id",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(go.goroutine.count{service.name=\"$service_name\"},service.instance.id)",
+          "refId": "VariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
         "type": "query"
       }
     ]

--- a/config/dashboards/go_runtime.json
+++ b/config/dashboards/go_runtime.json
@@ -18,7 +18,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 2,
+  "id": 3,
   "links": [],
   "panels": [
     {
@@ -26,6 +26,7 @@
         "type": "victoriametrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The goroutines used and processors available, averaged across all instances of a service.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -70,8 +71,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -97,11 +97,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "datasource": {
@@ -135,6 +136,7 @@
         "type": "victoriametrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The memory allocated, averaged across all instances of a service.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -178,8 +180,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -206,11 +207,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "editorMode": "code",
@@ -250,7 +252,7 @@
     }
   ],
   "preload": false,
-  "schemaVersion": 40,
+  "schemaVersion": 41,
   "tags": [],
   "templating": {
     "list": [
@@ -284,6 +286,5 @@
   "timezone": "browser",
   "title": "Go Runtime",
   "uid": "ae9uxps6dea68b",
-  "version": 1,
-  "weekStart": ""
+  "version": 1
 }

--- a/config/dashboards/grpc.json
+++ b/config/dashboards/grpc.json
@@ -18,7 +18,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 4,
+  "id": 3,
   "links": [],
   "panels": [
     {
@@ -55,7 +55,7 @@
         "content": "This dashboard provides visualisations for 3 of the 4 golden signals: Errors,\nLatency and Traffic.\n\nIt aims to track compliance with the following [SLOs][1]:\n\n* 99% of requests must be served within 100ms.\n* 99% of requests must result in a success response.\n\nThe following [status codes][2] are considered to be error responses.\n\n- Unknown (2)\n- DeadlineExceeded (4)\n- Unimplemented (12)\n- Internal (13)\n- Unavailable (14)\n- Data Loss (15)\n\n[1]: https://sre.google/sre-book/service-level-objectives/\n[2]: https://grpc.io/docs/guides/status-codes/",
         "mode": "markdown"
       },
-      "pluginVersion": "11.6.1",
+      "pluginVersion": "12.0.0",
       "title": "",
       "type": "text"
     },
@@ -77,6 +77,7 @@
         "type": "victoriametrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The percentage of requests that exceeded the latency threshold across the current time range.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -127,7 +128,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.6.1",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "datasource": {
@@ -150,6 +151,7 @@
         "type": "victoriametrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The percentage of requests that resulted in error responses across the current time range.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -200,7 +202,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.6.1",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "editorMode": "code",
@@ -339,6 +341,7 @@
         "type": "victoriametrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The percentage of requests that exceeded the latency threshold.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -413,7 +416,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.1",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "datasource": {
@@ -436,6 +439,7 @@
         "type": "victoriametrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The percentage of requests that resulted in error responses.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -514,7 +518,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.1",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "editorMode": "code",
@@ -666,12 +670,14 @@
         "type": "victoriametrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The P99 latency for success responses across the current time range.",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
           "mappings": [],
+          "min": 0,
           "noValue": "N/A",
           "thresholds": {
             "mode": "absolute",
@@ -695,7 +701,7 @@
         "x": 0,
         "y": 21
       },
-      "id": 5,
+      "id": 10,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
@@ -713,12 +719,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.6.1",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "editorMode": "code",
           "exemplar": false,
-          "expr": "histogram_quantile(0.5, sum(increase(rpc.server.duration_bucket{rpc.system=\"grpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.grpc.status_code!~\"2|4|12|13|14|15\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(increase(rpc.server.duration_bucket{rpc.system=\"grpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.grpc.status_code!~\"2|4|12|13|14|15\"}[$__rate_interval])) by (le))",
           "format": "time_series",
           "instant": false,
           "legendFormat": "p50",
@@ -726,7 +732,7 @@
           "refId": "A"
         }
       ],
-      "title": "P50 Average (Success)",
+      "title": "P99 Average (Success)",
       "type": "stat"
     },
     {
@@ -734,6 +740,7 @@
         "type": "victoriametrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The P99 latency for error responses across the current time range.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -764,7 +771,7 @@
         "x": 4,
         "y": 21
       },
-      "id": 6,
+      "id": 9,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
@@ -782,12 +789,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.6.1",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "editorMode": "code",
           "exemplar": false,
-          "expr": "histogram_quantile(0.5, sum(increase(rpc.server.duration_bucket{rpc.system=\"grpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.grpc.status_code=~\"2|4|12|13|14|15\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(increase(rpc.server.duration_bucket{rpc.system=\"grpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.grpc.status_code=~\"2|4|12|13|14|15\"}[$__rate_interval])) by (le))",
           "format": "time_series",
           "instant": false,
           "legendFormat": "p50",
@@ -795,7 +802,7 @@
           "refId": "A"
         }
       ],
-      "title": "P50 Average (Error)",
+      "title": "P99 Average (Error)",
       "type": "stat"
     },
     {
@@ -803,6 +810,7 @@
         "type": "victoriametrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The P90 latency for success responses across the current time range.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -851,7 +859,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.6.1",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "editorMode": "code",
@@ -872,6 +880,7 @@
         "type": "victoriametrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The P90 latency for error responses across the current time range.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -920,7 +929,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.6.1",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "editorMode": "code",
@@ -941,13 +950,13 @@
         "type": "victoriametrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The P50 latency for success responses across the current time range.",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
           "mappings": [],
-          "min": 0,
           "noValue": "N/A",
           "thresholds": {
             "mode": "absolute",
@@ -971,7 +980,7 @@
         "x": 16,
         "y": 21
       },
-      "id": 10,
+      "id": 5,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
@@ -989,12 +998,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.6.1",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "editorMode": "code",
           "exemplar": false,
-          "expr": "histogram_quantile(0.99, sum(increase(rpc.server.duration_bucket{rpc.system=\"grpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.grpc.status_code!~\"2|4|12|13|14|15\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.5, sum(increase(rpc.server.duration_bucket{rpc.system=\"grpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.grpc.status_code!~\"2|4|12|13|14|15\"}[$__rate_interval])) by (le))",
           "format": "time_series",
           "instant": false,
           "legendFormat": "p50",
@@ -1002,7 +1011,7 @@
           "refId": "A"
         }
       ],
-      "title": "P99 Average (Success)",
+      "title": "P50 Average (Success)",
       "type": "stat"
     },
     {
@@ -1010,6 +1019,7 @@
         "type": "victoriametrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The P50 latency for error responses across the current time range.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1040,7 +1050,7 @@
         "x": 20,
         "y": 21
       },
-      "id": 9,
+      "id": 6,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
@@ -1058,12 +1068,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.6.1",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "editorMode": "code",
           "exemplar": false,
-          "expr": "histogram_quantile(0.99, sum(increase(rpc.server.duration_bucket{rpc.system=\"grpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.grpc.status_code=~\"2|4|12|13|14|15\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.5, sum(increase(rpc.server.duration_bucket{rpc.system=\"grpc\",service.name=~\"$service_name\",rpc.service=~\"$rpc_service\",rpc.method=~\"$rpc_method\",rpc.grpc.status_code=~\"2|4|12|13|14|15\"}[$__rate_interval])) by (le))",
           "format": "time_series",
           "instant": false,
           "legendFormat": "p50",
@@ -1071,7 +1081,7 @@
           "refId": "A"
         }
       ],
-      "title": "P99 Average (Error)",
+      "title": "P50 Average (Error)",
       "type": "stat"
     },
     {
@@ -1079,6 +1089,7 @@
         "type": "victoriametrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The latency for all responses.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1155,7 +1166,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.1",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "datasource": {
@@ -1201,6 +1212,7 @@
         "type": "victoriametrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The latency for success responses.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1277,7 +1289,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.1",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "datasource": {
@@ -1323,6 +1335,7 @@
         "type": "victoriametrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The latency for error responses.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1399,7 +1412,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.1",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "datasource": {
@@ -1458,6 +1471,7 @@
         "type": "victoriametrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "Total responses by status code for the current time range.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1503,7 +1517,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.1",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "editorMode": "code",
@@ -1642,6 +1656,7 @@
         "type": "victoriametrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The number of responses.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1712,7 +1727,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.1",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "editorMode": "code",
@@ -1730,6 +1745,7 @@
         "type": "victoriametrics-datasource",
         "uid": "victoriametrics"
       },
+      "description": "The number of responses by error code.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1804,7 +1820,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.1",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "editorMode": "code",
@@ -1952,6 +1968,7 @@
           "value": "$__all"
         },
         "definition": "label_values(rpc.server.duration_bucket{rpc.system=\"grpc\"},service.name)",
+        "description": "Filter panels by service name.",
         "includeAll": true,
         "label": "Service Name",
         "name": "service_name",
@@ -1972,6 +1989,7 @@
           "value": "$__all"
         },
         "definition": "label_values(rpc.server.duration_bucket{rpc.system=\"grpc\",service.name=~\"$service_name\"},rpc.service)",
+        "description": "Filter panels by RPC service.",
         "includeAll": true,
         "label": "RPC Service",
         "name": "rpc_service",
@@ -1992,6 +2010,7 @@
           "value": "$__all"
         },
         "definition": "label_values(rpc.server.duration_bucket{rpc.system=\"grpc\",service.name=~\"$service_name\", rpc.service=~\"$rpc_service\"},rpc.method)",
+        "description": "Filter panels by RPC method.",
         "includeAll": true,
         "label": "RPC Method",
         "name": "rpc_method",

--- a/internal/drivers/rpcserver/server.go
+++ b/internal/drivers/rpcserver/server.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"net/http/pprof"
 	"strconv"
 	"time"
 
@@ -19,8 +20,9 @@ const (
 
 // Config contains the configuration for creating a Server instance.
 type Config struct {
-	Host string `koanf:"host" default:"localhost"`
-	Port uint16 `koanf:"port" default:"5000"`
+	Host        string `koanf:"host" default:"localhost"`
+	Port        uint16 `koanf:"port" default:"5000"`
+	EnablePprof bool   `koanf:"enablepprof"`
 }
 
 // Handler implementations can register themselves to be hosted by the server.
@@ -35,15 +37,29 @@ type Server struct {
 
 // New creates a new Server instance from the given configuration.
 func NewFromConfig(config Config, handlers []Handler, opts []connect.HandlerOption) *Server {
-	return New(config.Host, config.Port, handlers, opts)
+	return New(config.Host, config.Port, config.EnablePprof, handlers, opts)
 }
 
 // New creates a new Server instance.
-func New(host string, port uint16, handlers []Handler, opts []connect.HandlerOption) *Server {
+func New(
+	host string,
+	port uint16,
+	enablePprof bool,
+	handlers []Handler,
+	opts []connect.HandlerOption,
+) *Server {
 	mux := http.NewServeMux()
 
 	for _, h := range handlers {
 		h.Register(mux, opts)
+	}
+
+	if enablePprof {
+		mux.HandleFunc("GET /debug/pprof/", pprof.Index)
+		mux.HandleFunc("GET /debug/pprof/cmdline", pprof.Cmdline)
+		mux.HandleFunc("GET /debug/pprof/profile", pprof.Profile)
+		mux.HandleFunc("GET /debug/pprof/symbol", pprof.Symbol)
+		mux.HandleFunc("GET /debug/pprof/trace", pprof.Trace)
 	}
 
 	return &Server{


### PR DESCRIPTION
Add descriptions to Grafana dashboard panels to improve usability.

Other changes:
- Adds optional pprof handlers to the RPC server to suport profiling. They can be enabled by setting the `APP_RPCSERVER_ENABLEPPROF` environment variable to `true`.
- Remove allocated memory visualisation from the Go runtime dashboard as it's confusing (see #265) and rely on used memory instead.
- Allow filtering by service instance in the Go runtime dashboard.
- Reorder ConnectRPC gRPC dashboard average latency panels to match the Database dashboard ordering.

Fixes #253.