### PR TITLE
Implement baggage propagation

### DIFF
--- a/cmd/example-rpc/wire.go
+++ b/cmd/example-rpc/wire.go
@@ -47,9 +47,10 @@ func ProvideApp(ctx context.Context) (*App, error) {
 			"TracerProvider",
 		),
 		// observability
-		otelx.NewTracerProviderFromConfig,
-		otelx.NewMeterProviderFromConfig,
-		otelx.NewLoggerProviderFromConfig,
+		baggageFilter,
+		otelx.SetupTracerProviderFromConfig,
+		otelx.SetupMeterProviderFromConfig,
+		otelx.SetupLoggerProviderFromConfig,
 		loggerOptions,
 		logging.NewAsDefaultFromConfig,
 		// providers

--- a/cmd/example-rpc/wire_gen.go
+++ b/cmd/example-rpc/wire_gen.go
@@ -82,17 +82,18 @@ func ProvideApp(ctx context.Context) (*App, error) {
 	v5 := collectHandlerOptions(v4, recoverer)
 	server := rpcserver.NewFromConfig(rpcserverConfig, v2, v5)
 	tracerProviderConfig := mainConfig.TracerProvider
-	tracerProviderShutdown, err := otelx.NewTracerProviderFromConfig(ctx, tracerProviderConfig)
+	filter := baggageFilter()
+	tracerProviderShutdown, err := otelx.SetupTracerProviderFromConfig(ctx, tracerProviderConfig, filter)
 	if err != nil {
 		return nil, err
 	}
 	meterProviderConfig := mainConfig.MeterProvider
-	meterProviderShutdown, err := otelx.NewMeterProviderFromConfig(ctx, meterProviderConfig)
+	meterProviderShutdown, err := otelx.SetupMeterProviderFromConfig(ctx, meterProviderConfig)
 	if err != nil {
 		return nil, err
 	}
 	loggerProviderConfig := mainConfig.LoggerProvider
-	loggerProviderShutdown, err := otelx.NewLoggerProviderFromConfig(ctx, loggerProviderConfig)
+	loggerProviderShutdown, err := otelx.SetupLoggerProviderFromConfig(ctx, loggerProviderConfig, filter)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/example-rpc/wire_providers.go
+++ b/cmd/example-rpc/wire_providers.go
@@ -6,6 +6,7 @@ import (
 	"connectrpc.com/grpcreflect"
 	"connectrpc.com/otelconnect"
 	"connectrpc.com/validate"
+	"go.opentelemetry.io/contrib/processors/baggagecopy"
 
 	"github.com/mattdowdell/sandbox/internal/adapters/examplerpc"
 	"github.com/mattdowdell/sandbox/internal/adapters/healthrpc"
@@ -16,6 +17,11 @@ import (
 	"github.com/mattdowdell/sandbox/internal/drivers/rpcserver/interceptors/authn"
 	logginginterceptor "github.com/mattdowdell/sandbox/internal/drivers/rpcserver/interceptors/logging"
 )
+
+// ...
+func baggageFilter() baggagecopy.Filter {
+	return baggagecopy.AllowAllMembers
+}
 
 // loggerOptions provides logger configuration options.
 func loggerOptions() []logging.Option {
@@ -89,6 +95,7 @@ func collectHandlerOptions(
 	}
 }
 
+// ...
 func authnOptions() []authn.Option {
 	return []authn.Option{
 		authn.WithIgnoreService(

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/contrib/bridges/otelslog v0.10.0
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.60.0
+	go.opentelemetry.io/contrib/processors/baggagecopy v0.8.0
 	go.opentelemetry.io/otel v1.35.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.11.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.35.0

--- a/go.sum
+++ b/go.sum
@@ -213,6 +213,8 @@ go.opentelemetry.io/contrib/bridges/otelslog v0.10.0 h1:lRKWBp9nWoBe1HKXzc3ovkro
 go.opentelemetry.io/contrib/bridges/otelslog v0.10.0/go.mod h1:D+iyUv/Wxbw5LUDO5oh7x744ypftIryiWjoj42I6EKs=
 go.opentelemetry.io/contrib/instrumentation/runtime v0.60.0 h1:0NgN/3SYkqYJ9NBlDfl/2lzVlwos/YQLvi8sUrzJRBE=
 go.opentelemetry.io/contrib/instrumentation/runtime v0.60.0/go.mod h1:oxpUfhTkhgQaYIjtBt3T3w135dLoxq//qo3WPlPIKkE=
+go.opentelemetry.io/contrib/processors/baggagecopy v0.8.0 h1:S96lhLDZWb6y4stsWfwCJbkKJZR7nxExCdPgzZ6Ttz8=
+go.opentelemetry.io/contrib/processors/baggagecopy v0.8.0/go.mod h1:qqSKcb7JZWwGM6XSnvnwEskk2NaUqh6wlYsmwnTrvZo=
 go.opentelemetry.io/otel v1.35.0 h1:xKWKPxrxB6OtMCbmMY021CqC45J+3Onta9MqjhnusiQ=
 go.opentelemetry.io/otel v1.35.0/go.mod h1:UEqy8Zp11hpkUrL73gSlELM0DupHoiq72dR+Zqel/+Y=
 go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.11.0 h1:C/Wi2F8wEmbxJ9Kuzw/nhP+Z9XaHYMkyDmXy6yR2cjw=

--- a/internal/drivers/otelx/logger.go
+++ b/internal/drivers/otelx/logger.go
@@ -3,6 +3,7 @@ package otelx
 import (
 	"context"
 
+	"go.opentelemetry.io/contrib/processors/baggagecopy"
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
 	"go.opentelemetry.io/otel/log/global"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
@@ -17,23 +18,25 @@ type LoggerProviderConfig struct {
 // LoggerProviderShutdown provides a dedicated type for the logger provider shutdown function.
 type LoggerProviderShutdown func(context.Context) error
 
-// NewLoggerProviderFromConfig calls NewLoggerProvider with the given configuration.
-func NewLoggerProviderFromConfig(
+// SetupLoggerProviderFromConfig calls NewLoggerProvider with the given configuration.
+func SetupLoggerProviderFromConfig(
 	ctx context.Context,
 	conf LoggerProviderConfig,
+	filter baggagecopy.Filter,
 ) (LoggerProviderShutdown, error) {
-	return NewLoggerProvider(ctx, conf.Endpoint)
+	return SetupLoggerProvider(ctx, conf.Endpoint, filter)
 }
 
-// NewLoggerProvider creates a new [log.LoggerProvider] and sets it as the default using
+// SetupLoggerProvider creates a new [log.LoggerProvider] and sets it as the default using
 // [global.SetLoggerProvider]. The returned function should be called when the process exits to
 // export any lingering logs.
 //
 // [log.LoggerProvider]: https://pkg.go.dev/go.opentelemetry.io/otel/log#LoggerProvider
 // [global.SetLoggerProvider]: https://pkg.go.dev/go.opentelemetry.io/otel/log/global#SetLoggerProvider
-func NewLoggerProvider(
+func SetupLoggerProvider(
 	ctx context.Context,
 	endpoint string,
+	filter baggagecopy.Filter,
 ) (LoggerProviderShutdown, error) {
 	exporter, err := otlploghttp.New(ctx, otlploghttp.WithEndpointURL(endpoint))
 	if err != nil {
@@ -46,6 +49,7 @@ func NewLoggerProvider(
 	}
 
 	provider := sdklog.NewLoggerProvider(
+		sdklog.WithProcessor(baggagecopy.NewLogProcessor(filter)),
 		sdklog.WithProcessor(sdklog.NewBatchProcessor(exporter)),
 		sdklog.WithResource(res),
 	)

--- a/internal/drivers/otelx/meter.go
+++ b/internal/drivers/otelx/meter.go
@@ -18,21 +18,21 @@ type MeterProviderConfig struct {
 // MeterProviderShutdown provides a dedicated type for the meter provider shutdown function.
 type MeterProviderShutdown func(context.Context) error
 
-// NewMeterProviderFromConfig calls NewMeterProvider with the given configuration.
-func NewMeterProviderFromConfig(
+// SetupMeterProviderFromConfig calls SetupMeterProvider with the given configuration.
+func SetupMeterProviderFromConfig(
 	ctx context.Context,
 	conf MeterProviderConfig,
 ) (MeterProviderShutdown, error) {
-	return NewMeterProvider(ctx, conf.Endpoint)
+	return SetupMeterProvider(ctx, conf.Endpoint)
 }
 
-// NewMeterProvider creates a new [metric.MeterProvider] and sets it as the default using
+// SetupMeterProvider creates a new [metric.MeterProvider] and sets it as the default using
 // [otel.SetMeterProvider]. The returned function should be called when the process exits to publish
 // any lingering metrics.
 //
 // [metric.MeterProvider]: https://pkg.go.dev/go.opentelemetry.io/otel/metric#MeterProvider
 // [otel.SetMeterProvider]: https://pkg.go.dev/go.opentelemetry.io/otel#SetMeterProvider
-func NewMeterProvider(
+func SetupMeterProvider(
 	ctx context.Context,
 	endpoint string,
 ) (MeterProviderShutdown, error) {

--- a/internal/drivers/otelx/propagator.go
+++ b/internal/drivers/otelx/propagator.go
@@ -1,0 +1,16 @@
+package otelx
+
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+)
+
+// setupPropagator configures propagation of W3C trace contexts and W3C baggage.
+func setupPropagator() {
+	otel.SetTextMapPropagator(
+		propagation.NewCompositeTextMapPropagator(
+			propagation.TraceContext{},
+			propagation.Baggage{},
+		),
+	)
+}

--- a/internal/drivers/otelx/tracer.go
+++ b/internal/drivers/otelx/tracer.go
@@ -3,6 +3,7 @@ package otelx
 import (
 	"context"
 
+	"go.opentelemetry.io/contrib/processors/baggagecopy"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -18,23 +19,28 @@ type TracerProviderConfig struct {
 // TracerProviderShutdown provides a dedicated type for the tracer provider shutdown function.
 type TracerProviderShutdown func(context.Context) error
 
-// NewMeterProviderFromConfig calls NewMeterProvider with the given configuration.
-func NewTracerProviderFromConfig(
+// SetupTracerProviderFromConfig calls SetupTracerProvider with the given configuration.
+func SetupTracerProviderFromConfig(
 	ctx context.Context,
 	conf TracerProviderConfig,
+	filter baggagecopy.Filter,
 ) (TracerProviderShutdown, error) {
-	return NewTracerProvider(ctx, conf.Endpoint)
+	return SetupTracerProvider(ctx, conf.Endpoint, filter)
 }
 
-// NewTracerProvider creates a new [trace.TracerProvider] and sets it as the default using
+// SetupTracerProvider creates a new [trace.TracerProvider] and sets it as the default using
 // [otel.SetTracerProvider]. The returned function should be called when the process exits to
 // publish any lingering spans.
 //
+// Propagation of W3C trace contexts and W3C baggage is also configured for both incoming requests
+// and outgoing requests when supported.
+//
 // [trace.TracerProvider]: https://pkg.go.dev/go.opentelemetry.io/otel/trace#TracerProvider
 // [otel.SetTracerProvider]: https://pkg.go.dev/go.opentelemetry.io/otel#SetTracerProvider
-func NewTracerProvider(
+func SetupTracerProvider(
 	ctx context.Context,
 	endpoint string,
+	filter baggagecopy.Filter,
 ) (TracerProviderShutdown, error) {
 	exporter, err := otlptracehttp.New(ctx, otlptracehttp.WithEndpointURL(endpoint))
 	if err != nil {
@@ -46,9 +52,12 @@ func NewTracerProvider(
 		return nil, err
 	}
 
+	setupPropagator()
+
 	provider := sdktrace.NewTracerProvider(
 		sdktrace.WithBatcher(exporter),
 		sdktrace.WithResource(res),
+		sdktrace.WithSpanProcessor(baggagecopy.NewSpanProcessor(filter)),
 	)
 	otel.SetTracerProvider(provider)
 

--- a/tests/functional/all_test.go
+++ b/tests/functional/all_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"flag"
-	"fmt"
 	"testing"
 
 	"github.com/cucumber/godog"
@@ -21,7 +20,10 @@ func init() {
 }
 
 func Test_ExampleService(t *testing.T) {
-	client := examplev1client.New("http://localhost:5000")
+	client, err := examplev1client.New("http://localhost:5000")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	o := opts
 	o.TestingT = t
@@ -45,8 +47,7 @@ func Test_ExampleService(t *testing.T) {
 
 func InitializeScenario(sc *godog.ScenarioContext) {
 	sc.Before(func(ctx context.Context, scen *godog.Scenario) (context.Context, error) {
-		fmt.Println("name:", scen.Name)
-		return ctx, nil
+		return examplev1client.AddScenarioToContext(ctx, scen), nil
 	})
 
 	sc.Given(`^a name of (\d+) printable ASCII characters$`, step.PrintableASCIIChars)

--- a/tests/utils/examplev1client/client.go
+++ b/tests/utils/examplev1client/client.go
@@ -6,6 +6,9 @@ import (
 	"net/http"
 
 	"connectrpc.com/connect"
+	"connectrpc.com/otelconnect"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
 
 	"github.com/mattdowdell/sandbox/gen/example/v1"
 	"github.com/mattdowdell/sandbox/gen/example/v1/examplev1connect"
@@ -20,7 +23,16 @@ type Client struct {
 }
 
 // ...
-func New(baseURL string) *Client {
+func New(baseURL string) (*Client, error) {
+	otelInterceptor, err := otelconnect.NewInterceptor()
+	if err != nil {
+		return nil, err
+	}
+
+	otel.SetTextMapPropagator(
+		propagation.NewCompositeTextMapPropagator(propagation.Baggage{}),
+	)
+
 	inner := examplev1connect.NewExampleServiceClient(
 		http.DefaultClient,
 		baseURL,
@@ -28,12 +40,13 @@ func New(baseURL string) *Client {
 			connect.UnaryInterceptorFunc(ValidateUnaryInterceptor),
 			connect.UnaryInterceptorFunc(ScenarioUnaryInterceptor),
 			connect.UnaryInterceptorFunc(AuthnUnaryInterceptor),
+			otelInterceptor,
 		),
 	)
 
 	return &Client{
 		inner: inner,
-	}
+	}, nil
 }
 
 // ...

--- a/tests/utils/examplev1client/scenario.go
+++ b/tests/utils/examplev1client/scenario.go
@@ -2,6 +2,8 @@ package examplev1client
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"connectrpc.com/connect"
 	"go.opentelemetry.io/otel/baggage"
@@ -14,14 +16,20 @@ func ScenarioUnaryInterceptor(next connect.UnaryFunc) connect.UnaryFunc {
 		req connect.AnyRequest,
 	) (connect.AnyResponse, error) {
 		if scenario, ok := ScenarioFromContext(ctx); ok && scenario != "" {
-			s, err := baggage.NewMember("scenario.name", scenario)
+			s, err := baggage.NewMember("scenario.name", strings.ReplaceAll(scenario, " ", "_"))
 			if err != nil {
-				return nil, connect.NewError(connect.CodeCanceled, err)
+				return nil, connect.NewError(
+					connect.CodeCanceled,
+					fmt.Errorf("failed to create baggage member: %w", err),
+				)
 			}
 
 			b, err := baggage.New(s)
 			if err != nil {
-				return nil, connect.NewError(connect.CodeCanceled, err)
+				return nil, connect.NewError(
+					connect.CodeCanceled,
+					fmt.Errorf("failed to create baggage: %w", err),
+				)
 			}
 
 			ctx = baggage.ContextWithBaggage(ctx, b)

--- a/vendor/go.opentelemetry.io/contrib/processors/baggagecopy/LICENSE
+++ b/vendor/go.opentelemetry.io/contrib/processors/baggagecopy/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/go.opentelemetry.io/contrib/processors/baggagecopy/doc.go
+++ b/vendor/go.opentelemetry.io/contrib/processors/baggagecopy/doc.go
@@ -1,0 +1,37 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package baggagecopy is an OpenTelemetry [Span Processor] and [Log Record Processor]
+// that reads key/values stored in [Baggage] in context provided to copy onto the span or log.
+//
+// The SpanProcessor retrieves [Baggage] from the starting span's parent context
+// and adds them as attributes to the span.
+//
+// Keys and values added to Baggage will appear on all subsequent child spans for
+// a trace within this service and will be propagated to external services via
+// propagation headers.
+// If the external services also have a Baggage span processor, the keys and
+// values will appear in those child spans as well.
+//
+// The LogProcessor retrieves [Baggage] from the the context provided when
+// emitting the log and adds them as attributes to the log.
+// Baggage may be propagated to external services via propagation headers.
+// and be used to add context to logs if the service also has a Baggage log processor.
+//
+// Do not put sensitive information in Baggage.
+//
+// # Usage
+//
+// Add the span processor when configuring the tracer provider.
+//
+// Add the log processor when configuring the logger provider.
+//
+// The convenience function [AllowAllBaggageKeys] is provided to
+// allow all baggage keys to be copied. Alternatively, you can
+// provide a custom baggage key predicate to select which baggage keys you want
+// to copy.
+//
+// [Span Processor]: https://opentelemetry.io/docs/specs/otel/trace/sdk/#span-processor
+// [Log Record Processor]: https://opentelemetry.io/docs/specs/otel/logs/sdk/#logrecordprocessor
+// [Baggage]: https://opentelemetry.io/docs/specs/otel/api/baggage
+package baggagecopy // import "go.opentelemetry.io/contrib/processors/baggagecopy"

--- a/vendor/go.opentelemetry.io/contrib/processors/baggagecopy/log_processor.go
+++ b/vendor/go.opentelemetry.io/contrib/processors/baggagecopy/log_processor.go
@@ -1,0 +1,57 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package baggagecopy // import "go.opentelemetry.io/contrib/processors/baggagecopy"
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/baggage"
+	api "go.opentelemetry.io/otel/log"
+	"go.opentelemetry.io/otel/sdk/log"
+)
+
+// LogProcessor is a [log.Processor] implementation that adds baggage
+// members onto a log as attributes.
+type LogProcessor struct {
+	filter Filter
+}
+
+var _ log.Processor = (*LogProcessor)(nil)
+
+// NewLogProcessor returns a new [LogProcessor].
+//
+// The Baggage log processor adds attributes to a log record that are found
+// in Baggage in the parent context at the moment the log is emitted.
+// The passed filter determines which baggage members are added to the span.
+//
+// If filter is nil, all baggage members will be added.
+func NewLogProcessor(filter Filter) *LogProcessor {
+	return &LogProcessor{
+		filter: filter,
+	}
+}
+
+// OnEmit adds Baggage member to a log record as attributes that are pulled from
+// the Baggage found in ctx. Baggage members are filtered by the filter passed
+// to NewLogProcessor.
+func (processor LogProcessor) OnEmit(ctx context.Context, record *log.Record) error {
+	filter := processor.filter
+	if filter == nil {
+		filter = AllowAllMembers
+	}
+
+	for _, member := range baggage.FromContext(ctx).Members() {
+		if filter(member) {
+			record.AddAttributes(api.String(member.Key(), member.Value()))
+		}
+	}
+
+	return nil
+}
+
+// Shutdown is called when the [log.Processor] is shutting down and is a no-op for this processor.
+func (processor LogProcessor) Shutdown(context.Context) error { return nil }
+
+// ForceFlush is called to ensure all logs are flushed to the output and is a no-op for this processor.
+func (processor LogProcessor) ForceFlush(context.Context) error { return nil }

--- a/vendor/go.opentelemetry.io/contrib/processors/baggagecopy/processor.go
+++ b/vendor/go.opentelemetry.io/contrib/processors/baggagecopy/processor.go
@@ -1,0 +1,63 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package baggagecopy // import "go.opentelemetry.io/contrib/processors/baggagecopy"
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/baggage"
+	"go.opentelemetry.io/otel/sdk/trace"
+)
+
+// Filter returns true if the baggage member should be added to a span.
+type Filter func(member baggage.Member) bool
+
+// AllowAllMembers allows all baggage members to be added to a span.
+var AllowAllMembers Filter = func(baggage.Member) bool { return true }
+
+// SpanProcessor is a [trace.SpanProcessor] implementation that adds baggage
+// members onto a span as attributes.
+type SpanProcessor struct {
+	filter Filter
+}
+
+var _ trace.SpanProcessor = (*SpanProcessor)(nil)
+
+// NewSpanProcessor returns a new [SpanProcessor].
+//
+// The Baggage span processor duplicates onto a span the attributes found
+// in Baggage in the parent context at the moment the span is started.
+// The passed filter determines which baggage members are added to the span.
+//
+// If filter is nil, all baggage members will be added.
+func NewSpanProcessor(filter Filter) *SpanProcessor {
+	return &SpanProcessor{
+		filter: filter,
+	}
+}
+
+// OnStart is called when a span is started and adds span attributes for baggage contents.
+func (processor SpanProcessor) OnStart(ctx context.Context, span trace.ReadWriteSpan) {
+	filter := processor.filter
+	if filter == nil {
+		filter = AllowAllMembers
+	}
+
+	for _, member := range baggage.FromContext(ctx).Members() {
+		if filter(member) {
+			span.SetAttributes(attribute.String(member.Key(), member.Value()))
+		}
+	}
+}
+
+// OnEnd is called when span is finished and is a no-op for this processor.
+func (processor SpanProcessor) OnEnd(s trace.ReadOnlySpan) {}
+
+// Shutdown is called when the SDK shuts down and is a no-op for this processor.
+func (processor SpanProcessor) Shutdown(context.Context) error { return nil }
+
+// ForceFlush exports all ended spans to the configured Exporter that have not yet
+// been exported and is a no-op for this processor.
+func (processor SpanProcessor) ForceFlush(context.Context) error { return nil }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -391,6 +391,9 @@ go.opentelemetry.io/contrib/bridges/otelslog
 go.opentelemetry.io/contrib/instrumentation/runtime
 go.opentelemetry.io/contrib/instrumentation/runtime/internal/deprecatedruntime
 go.opentelemetry.io/contrib/instrumentation/runtime/internal/x
+# go.opentelemetry.io/contrib/processors/baggagecopy v0.8.0
+## explicit; go 1.22.0
+go.opentelemetry.io/contrib/processors/baggagecopy
 # go.opentelemetry.io/otel v1.35.0
 ## explicit; go 1.22.0
 go.opentelemetry.io/otel


### PR DESCRIPTION
Add support for baggage propagation to enable functional tests to pass the test scenario name to the server. Also copy baggage into log and span attributes using the OpenTelemetry SDK.

- Store the test scenario name in baggage, replacing spaces with underscores.
- Configure baggage propagation in the test ConnectRPC client.
- Configure baggage and trace propagation in the ConnectRPC server.
- Configure a baggage span processor to add baggage as span attributes.
- Configure a baggage log processor to add baggage as log attributes.

Due to baggage log processing being part of the OpenTelemetry ecosystem, baggage is not included on logs output to stdout. Instead, baggage is only added when exporting logs via OTLP. A brief investigation was conducted into whether logs could also be exported to stdout and gain baggage that way, but the output format was excessively verbose and significantly reduce debuggability.

At present, all baggage members are added to logs and spans. This can be reduced to a statis or dynamic allowlist by re-implementing the filter added in `wire_providers.go`.

Fixes #218.