### PR TITLE
Add unit tests for otelx driver

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -26,7 +26,6 @@ services:
       APP_METERPROVIDER_PATH: "/opentelemetry/v1/metrics"
       APP_TRACERPROVIDER_INSECURE: "true"
       APP_TRACERPROVIDER_ENDPOINT: "jaeger:4318"
-      # TODO: need to suppress path?
       APP_LOGGERPROVIDER_INSECURE: "true"
       APP_LOGGERPROVIDER_ENDPOINT: "victoria-logs:9428"
       APP_LOGGERPROVIDER_PATH: "/insert/opentelemetry/v1/logs"

--- a/compose.yaml
+++ b/compose.yaml
@@ -21,9 +21,15 @@ services:
       APP_LOGGING_LEVEL: "debug"
       APP_RPCSERVER_HOST: "0.0.0.0"
       APP_RPCSERVER_ENABLEPPROF: "true"
-      APP_METERPROVIDER_ENDPOINT: "http://victoria-metrics:8428/opentelemetry/v1/metrics"
-      APP_TRACERPROVIDER_ENDPOINT: "http://jaeger:4318"
-      APP_LOGGERPROVIDER_ENDPOINT: "http://victoria-logs:9428/insert/opentelemetry/v1/logs"
+      APP_METERPROVIDER_INSECURE: "true"
+      APP_METERPROVIDER_ENDPOINT: "victoria-metrics:8428"
+      APP_METERPROVIDER_PATH: "/opentelemetry/v1/metrics"
+      APP_TRACERPROVIDER_INSECURE: "true"
+      APP_TRACERPROVIDER_ENDPOINT: "jaeger:4318"
+      # TODO: need to suppress path?
+      APP_LOGGERPROVIDER_INSECURE: "true"
+      APP_LOGGERPROVIDER_ENDPOINT: "victoria-logs:9428"
+      APP_LOGGERPROVIDER_PATH: "/insert/opentelemetry/v1/logs"
       OTEL_GO_X_DEPRECATED_RUNTIME_METRICS: "false"
     ports:
       - "127.0.0.1:5000:5000"

--- a/internal/drivers/logging/handler.go
+++ b/internal/drivers/logging/handler.go
@@ -42,12 +42,14 @@ func (h *handler) Handle(ctx context.Context, record slog.Record) error {
 
 func (h *handler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	return &handler{
-		inner: h.inner.WithAttrs(attrs),
+		inner:      h.inner.WithAttrs(attrs),
+		extractors: h.extractors,
 	}
 }
 
 func (h *handler) WithGroup(name string) slog.Handler {
 	return &handler{
-		inner: h.inner.WithGroup(name),
+		inner:      h.inner.WithGroup(name),
+		extractors: h.extractors,
 	}
 }

--- a/internal/drivers/otelx/extractor.go
+++ b/internal/drivers/otelx/extractor.go
@@ -43,7 +43,7 @@ func (e *Extractor) Extract(ctx context.Context) []slog.Attr {
 	}
 
 	if e.withSpanID {
-		attrs = append(attrs, slog.String("span_id", spanCtx.TraceID().String()))
+		attrs = append(attrs, slog.String("span_id", spanCtx.SpanID().String()))
 	}
 
 	if e.withSampled {

--- a/internal/drivers/otelx/extractor_test.go
+++ b/internal/drivers/otelx/extractor_test.go
@@ -1,0 +1,46 @@
+package otelx_test
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mattdowdell/sandbox/internal/drivers/otelx"
+)
+
+func Test_Extractor_Extract_Valid(t *testing.T) {
+	// arrange
+	extractor := otelx.NewExtractor(
+		otelx.WithSpanID(true),
+		otelx.WithSampled(true),
+	)
+
+	ctx := otelx.MustSpan(t.Context(), testTraceID, testSpanID, true /*sampled*/)
+
+	// act
+	got := extractor.Extract(ctx)
+
+	// assert
+	want := []slog.Attr{
+		slog.String("trace_id", testTraceID),
+		slog.String("span_id", testSpanID),
+		slog.Bool("sampled", true),
+	}
+
+	assert.Equal(t, want, got)
+}
+
+func Test_Extractor_Extract_Invalid(t *testing.T) {
+	// arrange
+	extractor := otelx.NewExtractor(
+		otelx.WithSpanID(true),
+		otelx.WithSampled(true),
+	)
+
+	// act
+	got := extractor.Extract(t.Context())
+
+	// assert
+	assert.Empty(t, got)
+}

--- a/internal/drivers/otelx/helpers_test.go
+++ b/internal/drivers/otelx/helpers_test.go
@@ -1,0 +1,50 @@
+package otelx_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mattdowdell/sandbox/internal/drivers/otelx"
+)
+
+const (
+	testTraceID = "0123456789abcdef0123456789abcdef"
+	testSpanID  = "0123456789abcdef"
+)
+
+func Test_MustSpan_Success(t *testing.T) {
+	assert.NotPanics(t, func() {
+		otelx.MustSpan(t.Context(), testTraceID, testSpanID, true /*sampled*/)
+	})
+}
+
+func Test_MustSpan_Error(t *testing.T) {
+	testCases := []struct {
+		name    string
+		traceID string
+		spanID  string
+		want    string
+	}{
+		{
+			name:    "invalid trace id",
+			traceID: "invalid",
+			spanID:  testSpanID,
+			want:    "hex encoded trace-id must have length equals to 32",
+		},
+		{
+			name:    "invalid span id",
+			traceID: testTraceID,
+			spanID:  "invalid",
+			want:    "hex encoded span-id must have length equals to 16",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.PanicsWithError(t, tc.want, func() {
+				otelx.MustSpan(t.Context(), tc.traceID, tc.spanID, true /*sampled*/)
+			})
+		})
+	}
+}

--- a/internal/drivers/otelx/logger.go
+++ b/internal/drivers/otelx/logger.go
@@ -11,8 +11,14 @@ import (
 
 // LoggerProviderConfig contains configuration for configuring an OpenTelemetry logger provider.
 type LoggerProviderConfig struct {
-	// The URL of the OTLP HTTP endpoint to export logs to.
+	// Use HTTP instead of HTTPS for the log exporter's HTTP connection.
+	Insecure bool `koanf:"insecure"`
+
+	// The host and optional port for the log exporter to connect to.
 	Endpoint string `koanf:"endpoint"`
+
+	// The URL path the log exporter should send requests to.
+	Path string `koanf:"path" default:"/v1/logs"`
 }
 
 // LoggerProviderShutdown provides a dedicated type for the logger provider shutdown function.
@@ -24,7 +30,7 @@ func SetupLoggerProviderFromConfig(
 	conf LoggerProviderConfig,
 	filter baggagecopy.Filter,
 ) (LoggerProviderShutdown, error) {
-	return SetupLoggerProvider(ctx, conf.Endpoint, filter)
+	return SetupLoggerProvider(ctx, conf.Insecure, conf.Endpoint, conf.Path, filter)
 }
 
 // SetupLoggerProvider creates a new [log.LoggerProvider] and sets it as the default using
@@ -35,10 +41,20 @@ func SetupLoggerProviderFromConfig(
 // [global.SetLoggerProvider]: https://pkg.go.dev/go.opentelemetry.io/otel/log/global#SetLoggerProvider
 func SetupLoggerProvider(
 	ctx context.Context,
+	insecure bool,
 	endpoint string,
+	path string,
 	filter baggagecopy.Filter,
 ) (LoggerProviderShutdown, error) {
-	exporter, err := otlploghttp.New(ctx, otlploghttp.WithEndpointURL(endpoint))
+	opts := []otlploghttp.Option{
+		otlploghttp.WithEndpoint(endpoint),
+		otlploghttp.WithURLPath(path),
+	}
+	if insecure {
+		opts = append(opts, otlploghttp.WithInsecure())
+	}
+
+	exporter, err := otlploghttp.New(ctx, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/drivers/otelx/logger_test.go
+++ b/internal/drivers/otelx/logger_test.go
@@ -1,0 +1,66 @@
+//nolint:dupl // similar to meter_test.go/tracer_test.go
+package otelx_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/contrib/processors/baggagecopy"
+
+	"github.com/mattdowdell/sandbox/internal/drivers/otelx"
+)
+
+func isHTTP(scheme string) bool {
+	return scheme == "http"
+}
+
+func urlToLoggerProviderConfig(t *testing.T, input string) otelx.LoggerProviderConfig {
+	t.Helper()
+
+	u, err := url.Parse(input)
+	require.NoError(t, err)
+
+	return otelx.LoggerProviderConfig{
+		Insecure: isHTTP(u.Scheme),
+		Endpoint: u.Host,
+		Path:     u.Path,
+	}
+}
+
+func Test_SetupLoggerProviderFromConfig_Success(t *testing.T) {
+	// arrange
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	conf := urlToLoggerProviderConfig(t, server.URL)
+
+	// act
+	shutdown, err := otelx.SetupLoggerProviderFromConfig(t.Context(), conf, baggagecopy.AllowAllMembers)
+
+	// assert
+	if assert.NotNil(t, shutdown) {
+		assert.NoError(t, shutdown(t.Context()))
+	}
+
+	assert.NoError(t, err)
+}
+
+func Test_SetupLoggerProviderFromConfig_Error(t *testing.T) {
+	// arrange
+	conf := otelx.LoggerProviderConfig{
+		Endpoint: "\t",
+	}
+
+	// act
+	shutdown, err := otelx.SetupLoggerProviderFromConfig(t.Context(), conf, baggagecopy.AllowAllMembers)
+
+	// assert
+	assert.Nil(t, shutdown)
+	assert.EqualError(t, err, `parse "https://%09": invalid URL escape "%09"`)
+}

--- a/internal/drivers/otelx/meter.go
+++ b/internal/drivers/otelx/meter.go
@@ -11,8 +11,14 @@ import (
 
 // MeterProviderConfig contains configuration for configuring an OpenTelemetry meter provider.
 type MeterProviderConfig struct {
-	// The URL of the OTLP HTTP endpoint to export metrics to.
+	// Use HTTP instead of HTTPS for the metric exporter's HTTP connection.
+	Insecure bool `koanf:"insecure"`
+
+	// The host and optional port for the metric exporter to connect to.
 	Endpoint string `koanf:"endpoint"`
+
+	// The URL path the metric exporter should send requests to.
+	Path string `koanf:"path" default:"/v1/metrics"`
 }
 
 // MeterProviderShutdown provides a dedicated type for the meter provider shutdown function.
@@ -23,7 +29,7 @@ func SetupMeterProviderFromConfig(
 	ctx context.Context,
 	conf MeterProviderConfig,
 ) (MeterProviderShutdown, error) {
-	return SetupMeterProvider(ctx, conf.Endpoint)
+	return SetupMeterProvider(ctx, conf.Insecure, conf.Endpoint, conf.Path)
 }
 
 // SetupMeterProvider creates a new [metric.MeterProvider] and sets it as the default using
@@ -34,9 +40,19 @@ func SetupMeterProviderFromConfig(
 // [otel.SetMeterProvider]: https://pkg.go.dev/go.opentelemetry.io/otel#SetMeterProvider
 func SetupMeterProvider(
 	ctx context.Context,
+	insecure bool,
 	endpoint string,
+	path string,
 ) (MeterProviderShutdown, error) {
-	exporter, err := otlpmetrichttp.New(ctx, otlpmetrichttp.WithEndpointURL(endpoint))
+	opts := []otlpmetrichttp.Option{
+		otlpmetrichttp.WithEndpoint(endpoint),
+		otlpmetrichttp.WithURLPath(path),
+	}
+	if insecure {
+		opts = append(opts, otlpmetrichttp.WithInsecure())
+	}
+
+	exporter, err := otlpmetrichttp.New(ctx, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/drivers/otelx/meter_test.go
+++ b/internal/drivers/otelx/meter_test.go
@@ -1,0 +1,71 @@
+//nolint:dupl // similar to meter_test.go/tracer_test.go
+package otelx_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattdowdell/sandbox/internal/drivers/otelx"
+)
+
+func urlToMeterProviderConfig(t *testing.T, input string) otelx.MeterProviderConfig {
+	t.Helper()
+
+	u, err := url.Parse(input)
+	require.NoError(t, err)
+
+	return otelx.MeterProviderConfig{
+		Insecure: isHTTP(u.Scheme),
+		Endpoint: u.Host,
+		Path:     u.Path,
+	}
+}
+
+func Test_SetupMeterProviderFromConfig_Success(t *testing.T) {
+	// arrange
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	conf := urlToMeterProviderConfig(t, server.URL)
+
+	// act
+	shutdown, err := otelx.SetupMeterProviderFromConfig(t.Context(), conf)
+
+	// assert
+	if assert.NotNil(t, shutdown) {
+		assert.NoError(t, shutdown(t.Context()))
+	}
+
+	assert.NoError(t, err)
+}
+
+func Test_SetupMeterProviderFromConfig_Error(t *testing.T) {
+	// arrange
+	conf := otelx.MeterProviderConfig{
+		Endpoint: "\t",
+	}
+
+	// act
+	shutdown, err := otelx.SetupMeterProviderFromConfig(t.Context(), conf)
+
+	// assert
+	assert.Nil(t, shutdown)
+	assert.EqualError(t, err, `parse "https://%09/v1/metrics": invalid URL escape "%09"`)
+}
+
+func Test_Meter(t *testing.T) {
+	// arrange
+
+	// act
+	meter := otelx.Meter()
+
+	// assert
+	assert.NotNil(t, meter)
+}

--- a/internal/drivers/otelx/runtime.go
+++ b/internal/drivers/otelx/runtime.go
@@ -1,9 +1,14 @@
 package otelx
 
 import (
+	"path"
 	"runtime"
 	"runtime/debug"
 	"strings"
+)
+
+const (
+	unknownVersion = "(unknown)"
 )
 
 // packageName returns the package name of the caller, using skip to ignore 0 or more stack frames
@@ -31,9 +36,17 @@ func packageName(skip int) string {
 func packageVersion(pkg string) string {
 	info, ok := debug.ReadBuildInfo()
 	if !ok {
-		return "(unknown)"
+		return unknownVersion
 	}
 
+	return extractVersion(pkg, info)
+}
+
+// extractVersion returns the version of the given package using the given build info, or
+// "(unknown)" if no version could be identified.
+//
+// Build info is passed via an argument to support unit testing with runtime/debug.ParseBuildInfo.
+func extractVersion(pkg string, info *debug.BuildInfo) string {
 	mods := map[string]string{}
 
 	if isParent(info.Main.Path, pkg) {
@@ -52,12 +65,13 @@ func packageVersion(pkg string) string {
 		}
 	}
 
-	if version, ok := mods[pkg]; ok {
-		return version
+	for ; pkg != "."; pkg = path.Dir(pkg) {
+		if version, ok := mods[pkg]; ok {
+			return version
+		}
 	}
 
-	// TODO: filter modules to closest parent
-	return "unimplemented"
+	return unknownVersion
 }
 
 func isParent(mod, pkg string) bool {

--- a/internal/drivers/otelx/runtime_internal_test.go
+++ b/internal/drivers/otelx/runtime_internal_test.go
@@ -13,6 +13,11 @@ import (
 //
 // The use of tabs as delimiters is required by the parser. Furthermore, each line cannot be
 // prefixed with whitespace or it will be ignored by the parser.
+//
+// At time of writing, "go test ./path" does not compile in dependencies. As a result,
+// runtime/debug.ReadBuildInfo is insufficient for unit testing package version extraction. As a
+// workaround, the below is a hardcoded output. Happily, this also means the versions are fully
+// deterministic instead of changing with dependency updates.
 const buildInfoData = `go	go1.24.0
 path	github.com/mattdowdell/sandbox/cmd/example-health
 mod	github.com/mattdowdell/sandbox	v0.0.120

--- a/internal/drivers/otelx/runtime_internal_test.go
+++ b/internal/drivers/otelx/runtime_internal_test.go
@@ -1,0 +1,112 @@
+package otelx
+
+import (
+	"runtime/debug"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The output of "go version -m ./dist/example-health" with the "./dist/example-health: " prefix
+// replaced with "go\t" and all whitespace stripped from the start of each line.
+//
+// The use of tabs as delimiters is required by the parser. Furthermore, each line cannot be
+// prefixed with whitespace or it will be ignored by the parser.
+const buildInfoData = `go	go1.24.0
+path	github.com/mattdowdell/sandbox/cmd/example-health
+mod	github.com/mattdowdell/sandbox	v0.0.120
+dep	buf.build/gen/go/grpc/grpc/connectrpc/go	v1.18.1-20250429200738-0ee95b84c2c7.1
+dep	buf.build/gen/go/grpc/grpc/protocolbuffers/go	v1.36.6-20250429200738-0ee95b84c2c7.1
+dep	connectrpc.com/connect	v1.18.1
+dep	github.com/creasty/defaults	v1.8.0
+dep	github.com/fsnotify/fsnotify	v1.9.0
+dep	github.com/go-logr/logr	v1.4.2
+dep	github.com/go-logr/stdr	v1.2.2
+dep	github.com/go-viper/mapstructure/v2	v2.2.1
+dep	github.com/knadh/koanf/maps	v0.1.2
+dep	github.com/knadh/koanf/parsers/json	v1.0.0
+dep	github.com/knadh/koanf/parsers/toml	v0.1.0
+dep	github.com/knadh/koanf/parsers/yaml	v1.0.0
+dep	github.com/knadh/koanf/providers/env	v1.1.0
+dep	github.com/knadh/koanf/providers/file	v1.2.0
+dep	github.com/knadh/koanf/v2	v2.2.0
+dep	github.com/mitchellh/copystructure	v1.2.0
+dep	github.com/mitchellh/reflectwalk	v1.0.2
+dep	github.com/pelletier/go-toml	v1.9.5
+dep	github.com/samber/lo	v1.49.1
+dep	github.com/samber/slog-multi	v1.4.0
+dep	go.opentelemetry.io/auto/sdk	v1.1.0
+dep	go.opentelemetry.io/contrib/bridges/otelslog	v0.11.0
+dep	go.opentelemetry.io/otel	v1.36.0
+dep	go.opentelemetry.io/otel/log	v0.12.2
+dep	go.opentelemetry.io/otel/metric	v1.36.0
+dep	go.opentelemetry.io/otel/trace	v1.36.0
+dep	golang.org/x/sys	v0.33.0
+dep	golang.org/x/text	v0.25.0
+dep	google.golang.org/protobuf	v1.36.6
+dep	gopkg.in/yaml.v3	v3.0.1
+build	-buildmode=exe
+build	-compiler=gc
+build	-trimpath=true
+build	CGO_ENABLED=0
+build	GOARCH=arm64
+build	GOOS=darwin
+build	GOARM64=v8.0
+build	vcs=git
+build	vcs.revision=3e787e3884c31c32e4e3d83fb8cd87c0d4e28a88
+build	vcs.time=2025-05-27T09:23:42Z
+build	vcs.modified=true`
+
+func Test_extractVersion(t *testing.T) {
+	testCases := []struct {
+		name string
+		have string
+		want string
+	}{
+		{
+			name: "main",
+			have: "github.com/mattdowdell/sandbox/cmd/example-health",
+			want: "v0.0.120",
+		},
+		{
+			name: "dependency",
+			have: "go.opentelemetry.io/otel",
+			want: "v1.36.0",
+		},
+		{
+			name: "dependency subpackage",
+			have: "go.opentelemetry.io/otel/subpackage",
+			want: "v1.36.0",
+		},
+		{
+			name: "submodule",
+			have: "go.opentelemetry.io/otel/log",
+			want: "v0.12.2",
+		},
+		{
+			name: "submodule subpackage",
+			have: "go.opentelemetry.io/otel/log/subpackage",
+			want: "v0.12.2",
+		},
+		{
+			name: "not found",
+			have: "github.com/does/not/exist",
+			want: "(unknown)",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// arrange
+			info, err := debug.ParseBuildInfo(buildInfoData)
+			require.NoError(t, err)
+
+			// act
+			got := extractVersion(tc.have, info)
+
+			// assert
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/internal/drivers/otelx/tracer.go
+++ b/internal/drivers/otelx/tracer.go
@@ -12,8 +12,14 @@ import (
 
 // TracerProviderConfig contains configuration for configuring an OpenTelemetry tracer provider.
 type TracerProviderConfig struct {
-	// The URL of the OTLP HTTP endpoint to export traces to.
+	// Use HTTP instead of HTTPS for the trace exporter's HTTP connection.
+	Insecure bool `koanf:"insecure"`
+
+	// The host and optional port for the trace exporter to connect to.
 	Endpoint string `koanf:"endpoint"`
+
+	// The URL path the trace exporter should send requests to.
+	Path string `koanf:"path" default:"/v1/traces"`
 }
 
 // TracerProviderShutdown provides a dedicated type for the tracer provider shutdown function.
@@ -25,7 +31,7 @@ func SetupTracerProviderFromConfig(
 	conf TracerProviderConfig,
 	filter baggagecopy.Filter,
 ) (TracerProviderShutdown, error) {
-	return SetupTracerProvider(ctx, conf.Endpoint, filter)
+	return SetupTracerProvider(ctx, conf.Insecure, conf.Endpoint, conf.Path, filter)
 }
 
 // SetupTracerProvider creates a new [trace.TracerProvider] and sets it as the default using
@@ -39,10 +45,20 @@ func SetupTracerProviderFromConfig(
 // [otel.SetTracerProvider]: https://pkg.go.dev/go.opentelemetry.io/otel#SetTracerProvider
 func SetupTracerProvider(
 	ctx context.Context,
+	insecure bool,
 	endpoint string,
+	path string,
 	filter baggagecopy.Filter,
 ) (TracerProviderShutdown, error) {
-	exporter, err := otlptracehttp.New(ctx, otlptracehttp.WithEndpointURL(endpoint))
+	opts := []otlptracehttp.Option{
+		otlptracehttp.WithEndpoint(endpoint),
+		otlptracehttp.WithURLPath(path),
+	}
+	if insecure {
+		opts = append(opts, otlptracehttp.WithInsecure())
+	}
+
+	exporter, err := otlptracehttp.New(ctx, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/drivers/otelx/tracer_test.go
+++ b/internal/drivers/otelx/tracer_test.go
@@ -1,0 +1,74 @@
+//nolint:dupl // similar to meter_test.go/tracer_test.go
+package otelx_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/contrib/processors/baggagecopy"
+
+	"github.com/mattdowdell/sandbox/internal/drivers/otelx"
+)
+
+func urlToTracerProviderConfig(t *testing.T, input string) otelx.TracerProviderConfig {
+	t.Helper()
+
+	u, err := url.Parse(input)
+	require.NoError(t, err)
+
+	return otelx.TracerProviderConfig{
+		Insecure: isHTTP(u.Scheme),
+		Endpoint: u.Host,
+		Path:     u.Path,
+	}
+}
+
+func Test_SetupTracerProviderFromConfig_Success(t *testing.T) {
+	// arrange
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	conf := urlToTracerProviderConfig(t, server.URL)
+
+	// act
+	shutdown, err := otelx.SetupTracerProviderFromConfig(t.Context(), conf, baggagecopy.AllowAllMembers)
+
+	// assert
+	if assert.NotNil(t, shutdown) {
+		assert.NoError(t, shutdown(t.Context()))
+	}
+
+	assert.NoError(t, err)
+}
+
+func Test_SetupTracerProviderFromConfig_Error(t *testing.T) {
+	// arrange
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	conf := otelx.TracerProviderConfig{}
+
+	// act
+	shutdown, err := otelx.SetupTracerProviderFromConfig(ctx, conf, baggagecopy.AllowAllMembers)
+
+	// assert
+	assert.Nil(t, shutdown)
+	assert.EqualError(t, err, "context canceled")
+}
+
+func Test_Tracer(t *testing.T) {
+	// arrange
+
+	// act
+	meter := otelx.Tracer()
+
+	// assert
+	assert.NotNil(t, meter)
+}

--- a/pkg/slogx/context.go
+++ b/pkg/slogx/context.go
@@ -13,7 +13,9 @@ func FromContext(ctx context.Context) *slog.Logger {
 		return logger
 	}
 
-	return slog.Default()
+	d := slog.Default()
+	d.InfoContext(ctx, "from context")
+	return d
 }
 
 // IntoContext adds the given logger to the context, returning the new context.

--- a/pkg/slogx/context.go
+++ b/pkg/slogx/context.go
@@ -13,9 +13,7 @@ func FromContext(ctx context.Context) *slog.Logger {
 		return logger
 	}
 
-	d := slog.Default()
-	d.InfoContext(ctx, "from context")
-	return d
+	return slog.Default()
 }
 
 // IntoContext adds the given logger to the context, returning the new context.

--- a/tools/filter-coverage/main.go
+++ b/tools/filter-coverage/main.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"golang.org/x/mod/modfile"
 )
@@ -24,19 +25,42 @@ const (
 var (
 	modfilePath = flag.String("modfile", "go.mod", "The path of the go.mod file for the module under test")
 	output      = flag.String("output", "filtered.out", "The path to output to")
+	debug       = flag.Bool("debug", false, "Enable debug logging")
 )
+
+var level slog.LevelVar
 
 func main() {
 	os.Exit(run())
 }
 
 func run() int {
+	logger := slog.New(slog.NewTextHandler(flag.CommandLine.Output(), &slog.HandlerOptions{
+		Level: &level,
+		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+			if len(groups) > 0 {
+				return a
+			}
+
+			if a.Key == slog.TimeKey && a.Value.Kind() == slog.KindTime {
+				return slog.String(slog.TimeKey, a.Value.Time().Format(time.Kitchen))
+			}
+
+			return a
+		},
+	}))
+	slog.SetDefault(logger)
+
 	flag.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s <coverprofile>\n", filepath.Base(os.Args[0]))
 		flag.PrintDefaults()
 	}
 
 	flag.Parse()
+
+	if *debug {
+		level.Set(slog.LevelDebug)
+	}
 
 	if flag.NArg() < 1 {
 		slog.Error("missing argument")
@@ -99,7 +123,7 @@ func filterFile(profile *os.File, modPath string) (string, error) {
 			processed[filename] = generated
 
 			if generated {
-				slog.Info("skipping generated file", slog.String("filename", filename))
+				slog.Debug("skipping generated file", slog.String("filename", filename))
 			}
 		}
 


### PR DESCRIPTION
Adds unit tests for the otelx driver with the following modifications:

- Split up inputs for trace, metric and log exporters to allow detection of invalid URLs.
    - The trace exporter cannot detect invalid URLs, but received the change for consistency.
- Fix the extraction of span attributes for log fields to use the span ID instead of mistakenly adding the trace ID twice.
- Fully implement detection of package versions.

Other changes:
- Propagate context extractors when adding attributes and groups to a logger instance.
- Move info logs in tools/filter-coverage to debug, and use a less verbose timestamp.

Fixes #169.