### PR TITLE
Support Watch for k8smount koanf provider

### DIFF
--- a/internal/drivers/config/flagoptions/options.go
+++ b/internal/drivers/config/flagoptions/options.go
@@ -14,6 +14,11 @@ import (
 // - -config.envprefix is the prefix for environment variables to read configuration from.
 // - -config.files is a comma delimited list of files to read configuration from.
 // - -config.mounts is a comma delimited list of kubernetes pod mounts to read configuration from.
+//
+// Internally, a new [flag.FlagSet] instance is created with just the above flags allowed.
+// Unrecognised flags will cause the process to exit. This is usually acceptable for a binary, but
+// may cause problems if relying on flags defined in other modules/packages. In these cases, use
+// NewWithFlagSet to either set the global FlagSet instance or another instance.
 func New() *config.Options {
 	// copied from flag, apparently execl can cause os.Args to be empty
 	var name string

--- a/internal/drivers/config/flagoptions/options_test.go
+++ b/internal/drivers/config/flagoptions/options_test.go
@@ -31,7 +31,7 @@ func Test_New(t *testing.T) {
 	}{
 		{
 			name: "defaults",
-			args: []string{"example"},
+			args: []string{t.Name()},
 			want: &config.Options{
 				EnvPrefix: "APP_",
 				Files:     []string{},
@@ -41,7 +41,7 @@ func Test_New(t *testing.T) {
 		{
 			name: "arguments",
 			args: []string{
-				"example",
+				t.Name(),
 				"-config.envprefix=ARG_",
 				"-config.files=/etc/arg1,/etc/arg2",
 				"-config.mounts=/etc/arg3,/etc/arg4",
@@ -68,7 +68,7 @@ func Test_New(t *testing.T) {
 		{
 			name: "both",
 			args: []string{
-				"example",
+				t.Name(),
 				"-config.envprefix=ARG_",
 				"-config.files=/etc/arg1,/etc/arg2",
 				"-config.mounts=/etc/arg3,/etc/arg4",
@@ -108,7 +108,7 @@ func Test_NewWithFlagSet_Success(t *testing.T) {
 	// arrange
 	flagset := flag.NewFlagSet(t.Name(), flag.ContinueOnError)
 
-	setArgs(t, "example")
+	setArgs(t, t.Name())
 
 	// act
 	got, err := flagoptions.NewWithFlagSet(flagset)
@@ -128,7 +128,7 @@ func Test_NewWithFlagSet_Error(t *testing.T) {
 	// arrange
 	flagset := flag.NewFlagSet(t.Name(), flag.ContinueOnError)
 
-	setArgs(t, "example", "-invalid=invalid")
+	setArgs(t, t.Name(), "-invalid=invalid")
 
 	// act
 	got, err := flagoptions.NewWithFlagSet(flagset)

--- a/internal/drivers/config/providers/k8smount/example_test.go
+++ b/internal/drivers/config/providers/k8smount/example_test.go
@@ -1,0 +1,57 @@
+package k8smount_test
+
+import (
+	"log"
+
+	"github.com/knadh/koanf/v2"
+
+	"github.com/mattdowdell/sandbox/internal/drivers/config/providers/k8smount"
+)
+
+func ExampleK8SMount_Read() {
+	k := koanf.New(".")
+	provider := k8smount.Provider("/path/to/mount/", "." /*delimiter*/)
+
+	if err := k.Load(provider, nil /*parser*/); err != nil {
+		log.Fatal("config load failed:", err)
+		return
+	}
+
+	log.Println("config loaded: example=", k.Get("example"))
+}
+
+func ExampleK8SMount_Watch() {
+	k := koanf.New(".")
+	provider := k8smount.Provider("/path/to/mount/", "." /*delimiter*/)
+
+	if err := k.Load(provider, nil /*parser*/); err != nil {
+		log.Fatal("config load failed:", err)
+		return
+	}
+
+	log.Println("config loaded: example=", k.Get("example"))
+
+	if err := provider.Watch(func(err error) {
+		if err != nil {
+			log.Println("watch stopping:", err)
+			return
+		}
+
+		if err := k.Load(provider, nil /*parser*/); err != nil {
+			log.Println("config load failed:", err)
+
+			if err := provider.Unwatch(); err != nil {
+				log.Println("provider unwatch error:", err)
+			}
+
+			return
+		}
+
+		log.Println("config loaded: example=", k.Get("example"))
+	}); err != nil {
+		log.Fatal("watch failed:", err)
+	}
+
+	// wait forever
+	select {}
+}

--- a/internal/drivers/config/providers/k8smount/provider.go
+++ b/internal/drivers/config/providers/k8smount/provider.go
@@ -6,10 +6,19 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"strings"
+	"sync/atomic"
+	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/knadh/koanf/maps"
 	"github.com/knadh/koanf/v2"
+)
+
+var (
+	ErrUnexpectedEvent = errors.New("unexpected event")
+	ErrAlreadyWatched  = errors.New("mount is already being watched")
 )
 
 // Non-allocating compile-time check for interface implementation.
@@ -17,8 +26,10 @@ var _ koanf.Provider = (*K8SMount)(nil)
 
 // K8SMount implements a Kubernetes pod mount provider.
 type K8SMount struct {
-	mount string
-	delim string
+	mount    string
+	delim    string
+	watching atomic.Bool
+	watcher  *fsnotify.Watcher
 }
 
 // Provider creates a new K8SMount provider capable of reading in mounted secrets and configmaps in
@@ -30,7 +41,7 @@ type K8SMount struct {
 // being read as configuration.
 func Provider(mount, delim string) *K8SMount {
 	return &K8SMount{
-		mount: mount,
+		mount: filepath.Clean(mount),
 		delim: delim,
 	}
 }
@@ -79,4 +90,86 @@ func (k *K8SMount) Read() (map[string]any, error) {
 	}
 
 	return maps.Unflatten(values, k.delim), nil
+}
+
+// Watch starts a watcher in a goroutine for the files under the mount point and calls the given
+// function when changes occur.
+//
+// Only one watcher may be started at a time.
+//
+// If an error occurs, the function is called with the error before the watch is stopped. If the
+// function is called with a nil error value, a change was detected successfully and watching will
+// continue.
+func (k *K8SMount) Watch(fn func(err error)) error {
+	if k.watching.Swap(true) {
+		return ErrAlreadyWatched
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+
+	k.watcher = watcher
+	go k.watchDir(fn)
+
+	return watcher.Add(k.mount)
+}
+
+//nolint:gocognit // short enough that the complaxity is acceptable
+func (k *K8SMount) watchDir(fn func(err error)) {
+	defer k.watching.Store(false)
+
+	var (
+		lastEvent     string
+		lastEventTime time.Time
+	)
+
+	for {
+		select {
+		case event, ok := <-k.watcher.Events:
+			if !ok {
+				return
+			}
+
+			// Use a simple timer to buffer events as certain events fire
+			// multiple times on some platforms.
+			if event.String() == lastEvent && time.Since(lastEventTime) < time.Millisecond*5 {
+				continue
+			}
+
+			lastEvent = event.String()
+			lastEventTime = time.Now()
+
+			fmt.Println(event.String())
+
+			// mounts are only meant to be updated for the lifetime of the pod
+			if !event.Has(fsnotify.Write | fsnotify.Chmod) {
+				fn(fmt.Errorf("%w: %s", ErrUnexpectedEvent, event.String()))
+				return
+			}
+
+			// ignore chmod
+			if !event.Has(fsnotify.Chmod) {
+				fn(nil)
+			}
+
+		case err, ok := <-k.watcher.Errors:
+			if !ok {
+				return
+			}
+
+			fn(err)
+			return
+		}
+	}
+}
+
+// Unwatch stops a previously started Watch.
+func (k *K8SMount) Unwatch() error {
+	if k.watcher != nil {
+		return k.watcher.Close()
+	}
+
+	return nil
 }

--- a/internal/drivers/config/providers/k8smount/provider_test.go
+++ b/internal/drivers/config/providers/k8smount/provider_test.go
@@ -6,11 +6,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/mattdowdell/sandbox/internal/drivers/config/providers/k8smount"
 )
 
-func createFile(t *testing.T, root, path, content string) {
+func writeFile(t *testing.T, root, path, content string) {
 	t.Helper()
 
 	absPath := filepath.Join(root, path)
@@ -66,17 +67,18 @@ func Test_K8SMount_Read_WithFiles(t *testing.T) {
 	// arrange
 	dir := t.TempDir()
 
-	createFile(t, dir, "a", "a")
-	createFile(t, dir, "b.c", "c")
-	createFile(t, dir, "d.e.f", "f")
+	writeFile(t, dir, "a", "a")
+	writeFile(t, dir, "b.c", "c")
+	writeFile(t, dir, "d.e.f", "f")
+	writeFile(t, dir, "dir/file", "a") // should be ignored
 
 	provider := k8smount.Provider(dir, "." /*delim*/)
 
 	// act
-	values, err := provider.Read()
+	got, err := provider.Read()
 
 	// assert
-	expected := map[string]any{
+	want := map[string]any{
 		"a": "a",
 		"b": map[string]any{
 			"c": "c",
@@ -88,7 +90,7 @@ func Test_K8SMount_Read_WithFiles(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, expected, values)
+	assert.Equal(t, want, got)
 	assert.NoError(t, err)
 }
 
@@ -106,4 +108,98 @@ func Test_K8SMount_Read_MissingDir(t *testing.T) {
 		err,
 		`failed to read configuration from mount: "/does/not/exist": stat .: no such file or directory`,
 	)
+}
+
+func Test_K8SMount_Watch_Success(t *testing.T) {
+	// arrange
+	dir := t.TempDir()
+
+	writeFile(t, dir, "a", "a")
+
+	provider := k8smount.Provider(dir, "." /*delim*/)
+
+	_, err := provider.Read()
+	require.NoError(t, err)
+
+	watched := make(chan struct{})
+
+	// act
+	require.NoError(t, provider.Watch(func(err error) {
+		assert.NoError(t, err)
+		close(watched)
+	}))
+
+	writeFile(t, dir, "a", "b")
+
+	// assert
+	<-watched
+	require.NoError(t, provider.Unwatch())
+
+	got, err := provider.Read()
+
+	want := map[string]any{
+		"a": "b",
+	}
+
+	assert.Equal(t, want, got)
+	assert.NoError(t, err)
+}
+
+func Test_K8SMount_Watch_AlreadyWatching(t *testing.T) {
+	// arrange
+	dir := t.TempDir()
+	provider := k8smount.Provider(dir, "." /*delim*/)
+
+	require.NoError(t, provider.Watch(func(err error) {
+		assert.NoError(t, err)
+	}))
+	defer func() {
+		assert.NoError(t, provider.Unwatch())
+	}()
+
+	// act
+	err := provider.Watch(func(err error) {
+		assert.NoError(t, err)
+	})
+
+	// assert
+	assert.ErrorIs(t, err, k8smount.ErrAlreadyWatched)
+}
+
+func Test_K8SMount_Watch_UnexpectedEvent(t *testing.T) {
+	// arrange
+	dir := t.TempDir()
+
+	writeFile(t, dir, "a", "a")
+
+	provider := k8smount.Provider(dir, "." /*delim*/)
+
+	_, err := provider.Read()
+	require.NoError(t, err)
+
+	watched := make(chan struct{})
+
+	// act
+	require.NoError(t, provider.Watch(func(err error) {
+		assert.ErrorIs(t, err, k8smount.ErrUnexpectedEvent)
+		close(watched)
+	}))
+
+	os.Remove(filepath.Join(dir, "a"))
+
+	// assert
+	<-watched
+	require.NoError(t, provider.Unwatch())
+}
+
+func Test_K8SMount_Unwatch(t *testing.T) {
+	// arrange
+	dir := t.TempDir()
+	provider := k8smount.Provider(dir, "." /*delim*/)
+
+	// act
+	err := provider.Unwatch()
+
+	// assert
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
Add support for watching for file changes in the k8smount koanf provider, enabling hot reloading of configmaps and secrets.

Fixes #56.