### PR TITLE
Resolve zizmor warnings in regenerate workflow

### DIFF
--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -23,7 +23,7 @@ jobs:
             --method POST \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/${{ github.repository }}/issues/comments/${COMMENT_ID}/reactions \
+            /repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}/reactions \
             -f "content=+1"
         env:
           GH_TOKEN: ${{ github.token }}
@@ -32,12 +32,13 @@ jobs:
       - name: PR branch
         id: ref
         run: |
-          echo "ref=`gh pr view '${{ github.event.issue.number }}' \
-            --repo ${{ github.repository }} \
+          echo "ref=`gh pr view ${ISSUE_NUMBER} \
+            --repo ${GITHUB_REPOSITORY} \
             --template '{{ .headRefName }}' \
             --json headRefName`" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
 
       - name: Generate token
         id: app-token
@@ -100,11 +101,12 @@ jobs:
       - name: Report failure
         if: failure()
         run: |
-          url=`gh run --repo ${{ github.repository }} view ${{ github.run_id }} --json jobs --jq '.jobs[].url'`
+          url=`gh run --repo ${GITHUB_REPOSITORY} view ${GITHUB_RUN_ID} --json jobs --jq '.jobs[].url'`
 
-          gh pr comment '${{ github.event.issue.number }}' \
-            --repo ${{ github.repository }} \
+          gh pr comment ${ISSUE_NUMBER} \
+            --repo ${GITHUB_REPOSITORY} \
             --body "Regenerate failed. See the [logs](${url}) for more info."
         env:
           GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
 


### PR DESCRIPTION
Resolve warnings from zizmor in regenerate workflow related to expansion by replacing them with equivalent environment variables.