### PR TITLE
Fix k8smount koanf provider to actually work with volume mounts

### DIFF
--- a/internal/drivers/config/providers/k8smount/helper_test.go
+++ b/internal/drivers/config/providers/k8smount/helper_test.go
@@ -1,0 +1,79 @@
+package k8smount_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	configmapTimeFmt = "2006_01_02_15_04_05.0000000000"
+	dataDir          = "..data"
+)
+
+// writeVolumeMount creates a file structure that matches how a ConfigMap or Secret will be mounted
+// in a Kubernetes Pod.
+//
+// First, files are created for each data field. These exist within a timestamp-based directory,
+// likely when the ConfigMap or Secret was last modified.
+//
+//	..2025_06_28_09_28_32.3151791122/
+//	├── database.hostname
+//	├── database.name
+//	└── database.port
+//
+// A symlink is then created for "..data" to the directory containing the data:
+//
+//	..data -> ..2025_06_28_09_28_32.3151791122
+//
+// Finally, symlinks are created for the data files, via the "..data" symlink:
+//
+//	database.hostname -> ..data/database.hostname
+//	database.name -> ..data/database.name
+//	database.port -> ..data/database.port
+func writeVolumeMount(mount string, data map[string]string) error {
+	dir := time.Now().UTC().Format(configmapTimeFmt)
+
+	dirPath := filepath.Join(mount, dir)
+
+	for key, value := range data {
+		if err := writeFile(filepath.Join(dirPath, key), value); err != nil {
+			return err
+		}
+	}
+
+	if err := os.Chdir(mount); err != nil {
+		return fmt.Errorf("failed to change dir to %q: %w", mount, err)
+	}
+
+	if err := os.Symlink(dir, "..data"); err != nil {
+		return fmt.Errorf("failed to create %s symlink to %q: %w", "..data", dir, err)
+	}
+
+	for key := range data {
+		target := filepath.Join(dataDir, key)
+
+		if err := os.Symlink(target, key); err != nil {
+			return fmt.Errorf("failed to create %q symlink to %q: %w", key, target, err)
+		}
+	}
+
+	return nil
+}
+
+func writeFile(path, content string) error {
+	dir := filepath.Dir(path)
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("failed to create directory %q: %w", dir, err)
+	}
+
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		return fmt.Errorf("failed to create file %q: %w", path, err)
+	}
+
+	fmt.Println("created:", path)
+
+	return nil
+}

--- a/internal/drivers/config/providers/k8smount/provider.go
+++ b/internal/drivers/config/providers/k8smount/provider.go
@@ -36,7 +36,7 @@ type K8SMount struct {
 //
 // The given path should be the mount point of the configmap or secret. The delimiter is used to
 // create a hierarchy of keys based on the mounted filename. For example, a configmap mounted at
-// "/my/config/" with a key of "log.level" set to "INFO" would result in {"log":{"level":"INFO"}}
+// "/mnt/config/" with a key of "log.level" set to "INFO" would result in {"log":{"level":"INFO"}}
 // being read as configuration.
 func Provider(mount, delim string) *K8SMount {
 	return &K8SMount{
@@ -57,7 +57,7 @@ func (k *K8SMount) Read() (map[string]any, error) {
 		return nil, fmt.Errorf("failed to open mount: %w", err)
 	}
 
-	values := map[string]any{}
+	data := map[string]any{}
 	mountFS := root.FS()
 
 	if err := fs.WalkDir(mountFS, ".", func(path string, d fs.DirEntry, err error) error {
@@ -65,8 +65,13 @@ func (k *K8SMount) Read() (map[string]any, error) {
 			return err
 		}
 
-		// skip sub-directories as k8s resources can't use path separators in keys
-		if d.IsDir() {
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+
+		// skip sub-directories as path separators are invalid in keys
+		if info.IsDir() {
 			if path == "." {
 				return nil
 			}
@@ -74,20 +79,26 @@ func (k *K8SMount) Read() (map[string]any, error) {
 			return fs.SkipDir
 		}
 
+		// paths with a ".." prefix are reserved for the actual data files to be stored under
+		// instead of reading those, use symlinks in the root of the mount instead
+		if strings.HasPrefix(path, "..") {
+			return nil
+		}
+
 		content, err := fs.ReadFile(mountFS, path)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to read file: %w", err)
 		}
 
 		key := strings.TrimPrefix(path, k.mount)
-		values[key] = string(content)
+		data[key] = string(content)
 
 		return nil
 	}); err != nil {
 		return nil, fmt.Errorf("failed to read configuration from mount: %q: %w", k.mount, err)
 	}
 
-	return maps.Unflatten(values, k.delim), nil
+	return maps.Unflatten(data, k.delim), nil
 }
 
 // Watch starts a watcher in a goroutine for the files under the mount point and calls the given

--- a/internal/drivers/config/providers/k8smount/provider.go
+++ b/internal/drivers/config/providers/k8smount/provider.go
@@ -65,13 +65,9 @@ func (k *K8SMount) Read() (map[string]any, error) {
 			return err
 		}
 
-		info, err := d.Info()
-		if err != nil {
-			return err
-		}
-
 		// skip sub-directories as path separators are invalid in keys
-		if info.IsDir() {
+		// FIXME: data can be mounted at paths depending on how the pod volume is configured
+		if d.IsDir() {
 			if path == "." {
 				return nil
 			}

--- a/internal/drivers/config/providers/k8smount/provider_test.go
+++ b/internal/drivers/config/providers/k8smount/provider_test.go
@@ -12,21 +12,6 @@ import (
 	"github.com/mattdowdell/sandbox/internal/drivers/config/providers/k8smount"
 )
 
-func writeFile(t *testing.T, root, path, content string) {
-	t.Helper()
-
-	absPath := filepath.Join(root, path)
-	absDirPath := filepath.Dir(absPath)
-
-	if err := os.MkdirAll(absDirPath, 0o755); err != nil {
-		t.Fatalf("failed to create directory: %s", err)
-	}
-
-	if err := os.WriteFile(absPath, []byte(content), 0o600); err != nil {
-		t.Fatalf("failed to create file: %s", err)
-	}
-}
-
 func Test_New(t *testing.T) {
 	// arrange
 	dir := t.TempDir()
@@ -68,10 +53,10 @@ func Test_K8SMount_Read_WithFiles(t *testing.T) {
 	// arrange
 	dir := t.TempDir()
 
-	writeFile(t, dir, "a", "a")
-	writeFile(t, dir, "b.c", "c")
-	writeFile(t, dir, "d.e.f", "f")
-	writeFile(t, dir, "dir/file", "a") // should be ignored
+	require.NoError(t, writeFile(filepath.Join(dir, "a"), "a"))
+	require.NoError(t, writeFile(filepath.Join(dir, "b.c"), "c"))
+	require.NoError(t, writeFile(filepath.Join(dir, "d.e.f"), "f"))
+	require.NoError(t, writeFile(filepath.Join(dir, "dir", "file"), "a")) // should be ignored
 
 	provider := k8smount.Provider(dir, "." /*delim*/)
 
@@ -88,6 +73,36 @@ func Test_K8SMount_Read_WithFiles(t *testing.T) {
 			"e": map[string]any{
 				"f": "f",
 			},
+		},
+	}
+
+	assert.Equal(t, want, got)
+	assert.NoError(t, err)
+}
+
+func Test_K8SMount_Read_WithVolumeMount(t *testing.T) {
+	// arrange
+	dir := t.TempDir()
+
+	require.NoError(t, writeVolumeMount(dir, map[string]string{
+		"a.foo": "foo-value",
+		"b.bar": "bar-value",
+		"b.baz": "baz-value",
+	}))
+
+	provider := k8smount.Provider(dir, "." /*delim*/)
+
+	// act
+	got, err := provider.Read()
+
+	// assert
+	want := map[string]any{
+		"a": map[string]any{
+			"foo": "foo-value",
+		},
+		"b": map[string]any{
+			"bar": "bar-value",
+			"baz": "baz-value",
 		},
 	}
 
@@ -115,7 +130,7 @@ func Test_K8SMount_Watch_Success(t *testing.T) {
 	// arrange
 	dir := t.TempDir()
 
-	writeFile(t, dir, "a", "a")
+	require.NoError(t, writeFile(filepath.Join(dir, "a"), "a"))
 
 	provider := k8smount.Provider(dir, "." /*delim*/)
 
@@ -131,7 +146,7 @@ func Test_K8SMount_Watch_Success(t *testing.T) {
 	}))
 
 	for !watched.Load() {
-		writeFile(t, dir, "a", "b")
+		require.NoError(t, writeFile(filepath.Join(dir, "a"), "b"))
 	}
 
 	// assert
@@ -172,7 +187,7 @@ func Test_K8SMount_Watch_UnexpectedEvent(t *testing.T) {
 	// arrange
 	dir := t.TempDir()
 
-	writeFile(t, dir, "a", "a")
+	require.NoError(t, writeFile(filepath.Join(dir, "a"), "a"))
 
 	provider := k8smount.Provider(dir, "." /*delim*/)
 


### PR DESCRIPTION
Fix the k8smount koanf provider to actually work with volume mounts of secrets and configmaps.

Until now, the correctness of this provider has been limited to unit tests and had not been tested against actual Kubernetes. However, with the progress in #323, testing found that it chocked on the symlink structure created by Kubernetes, particularly a symlink to a directory.

This change now moves towards correctly reading configuration for data in a flat directory structure. Despite existing assertions that data cannot be in subdirectories, it seems to be possible by setting a path in the items array of a secret or configmap volume on a pod. Support for this will be deferred to a future PR.