### PR TITLE
Set GOTOOLCHAIN=local in container builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ARG GO_BUILD_ARGS=
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=bind,target=. \
     set -eux; \
-    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GOTOOLCHAIN=local \
     go build ${GO_BUILD_ARGS} -trimpath -ldflags="-buildid= -s -w" -o /go/bin/ ./cmd/...; \
     touch --date=@${SOURCE_DATE_EPOCH} /go/bin/*;
 


### PR DESCRIPTION
As of Go 1.21, Go will automatically use a newer compiler version if the build requires it as documented in [Go Toolchains](https://go.dev/doc/toolchain). For example, running `go install` with Go 1.21 against a module that require Go 1.23, Go 1.23 will be used instead.

This feature does not seem unreasonable for tool installs which can move ahead of the project's Go version. However, it is problematic for container builds which (in this project) are supposed to be hermetic. Having an unexpected variable means it is difficult to check what version of the compiler will be used.

To disable this feature, we can set `GOTOOLCHAIN=local`, which replaces the default `GOTOOLCHAIN=local+auto`.