### PR TITLE
Run `just gen-just` before `just checks` in regenerate workflow

### DIFF
--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -83,7 +83,8 @@ jobs:
       - name: Regenerate
         run: |
           # look for tool updates first as it can cause other commands to fail
-          just gen-just checks
+          just gen-just
+          just checks
 
       - name: Commit diff
         run: |

--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -82,15 +82,8 @@ jobs:
 
       - name: Regenerate
         run: |
-          if ! just checks; then
-            if ! git diff HEAD --quiet .tools.just; then
-              echo "regenerate updated .tools.just, retrying"
-              just checks
-            else
-              echo "unexpected failure"
-              exit 1
-            fi
-          fi
+          # look for tool updates first as it can cause other commands to fail
+          just gen-just checks
 
       - name: Commit diff
         run: |

--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -82,7 +82,15 @@ jobs:
 
       - name: Regenerate
         run: |
-          just checks
+          if ! just checks; then
+            if ! git diff HEAD --quiet .tools.just; then
+              echo "regenerate updated .tools.just, retrying"
+              just checks
+            else
+              echo "unexpected failure"
+              exit 1
+            fi
+          fi
 
       - name: Commit diff
         run: |


### PR DESCRIPTION
When bingo-managed tools are updated, `just gen-just` sets the new version into `.tools.just`. However, because `just` is still running, it does not update its variables to point to the new tools and subsequent recipes fails with the wrong version.

To fix this, we can run the `gen-just` recipe first. This is performed in a separate process to disable any re-use of outdated variables.

Happily, this change also fixes the outdated `.bingo/*.sum` files which Renovate doesn't seem to know how to update.