### PR TITLE
Expose monotonic time in Clock interface

### DIFF
--- a/internal/domain/repositories/clock.go
+++ b/internal/domain/repositories/clock.go
@@ -6,8 +6,17 @@ import (
 
 // Clock implementations provide the current time and operations based on the current time.
 type Clock interface {
-	// Now returns the current time in UTC.
-	Now() time.Time
+	// UTCNow returns the current time in UTC.
+	//
+	// This should be used when storing the time. It must not be used for calculating the duration
+	// between 2 points in time as it lacks any monotonic representation.
+	UTCNow() time.Time
+
+	// LocalNow returns the current time in the local timezone.
+	//
+	// This should only be used to calculate the durations between 2 points in time via the Since
+	// and Until methods.
+	LocalNow() time.Time
 
 	// Since returns the time elapsed since the given value. It is shorthand for Clock.Now().Sub(t).
 	Since(t time.Time) time.Duration

--- a/internal/drivers/clock/clock.go
+++ b/internal/drivers/clock/clock.go
@@ -18,17 +18,28 @@ func New() *Clock {
 	return &Clock{}
 }
 
-// Now returns the current time in UTC.
-func (c *Clock) Now() time.Time {
+// UTCNow returns the current time in UTC.
+//
+// This should be used when storing the time. It must not be used for calculating the duration
+// between 2 points in time as it lacks any monotonic representation.
+func (c *Clock) UTCNow() time.Time {
 	return time.Now().UTC()
+}
+
+// LocalNow returns the current time in the local timezone.
+//
+// This should only be used to calculate the durations between 2 points in time via the Since and
+// Until methods.
+func (c *Clock) LocalNow() time.Time {
+	return time.Now()
 }
 
 // Since returns the time elapsed since the given value.
 func (c *Clock) Since(t time.Time) time.Duration {
-	return c.Now().Sub(t)
+	return c.LocalNow().Sub(t)
 }
 
 // Until returns the duration until the given value.
 func (c *Clock) Until(t time.Time) time.Duration {
-	return t.Sub(c.Now())
+	return t.Sub(c.LocalNow())
 }

--- a/internal/drivers/clock/clock_test.go
+++ b/internal/drivers/clock/clock_test.go
@@ -16,12 +16,12 @@ func assertWithinRange(t *testing.T, expected, actual, delta time.Duration) {
 	assert.LessOrEqual(t, expected-delta, actual)
 }
 
-func Test_Clock_Now(t *testing.T) {
+func Test_Clock_UTCNow(t *testing.T) {
 	// arrange
 	c := clock.New()
 
 	// act
-	now := c.Now()
+	now := c.UTCNow()
 
 	// assert
 	assert.WithinDuration(t, time.Now(), now, time.Second)
@@ -30,6 +30,17 @@ func Test_Clock_Now(t *testing.T) {
 
 	assert.Equal(t, "UTC", zone)
 	assert.Equal(t, 0, offset)
+}
+
+func Test_Clock_LocalNow(t *testing.T) {
+	// arrange
+	c := clock.New()
+
+	// act
+	now := c.LocalNow()
+
+	// assert
+	assert.WithinDuration(t, time.Now(), now, time.Second)
 }
 
 func Test_Clock_Since(t *testing.T) {

--- a/internal/usecases/create_resource.go
+++ b/internal/usecases/create_resource.go
@@ -44,7 +44,7 @@ func (u *CreateResource) Execute(
 		return nil, domain.ErrInternal
 	}
 
-	resource.Init(id, u.clock.Now())
+	resource.Init(id, u.clock.UTCNow())
 
 	if err := store.CreateResource(ctx, resource); err != nil {
 		if errors.Is(err, domain.ErrAlreadyExists) {

--- a/internal/usecases/create_resource_test.go
+++ b/internal/usecases/create_resource_test.go
@@ -37,7 +37,7 @@ func Test_CreateResource_Success(t *testing.T) {
 	id := uuid.Must(uuid.NewV7())
 
 	clock := mockrepositories.NewClock(t)
-	clock.EXPECT().Now().Return(now).Once()
+	clock.EXPECT().UTCNow().Return(now).Once()
 
 	uuidgen := mockrepositories.NewUUIDGenerator(t)
 	uuidgen.EXPECT().NewV7().Return(id, nil).Once()
@@ -112,7 +112,7 @@ func Test_CreateResource_CreateFailed(t *testing.T) {
 			id := uuid.Must(uuid.NewV7())
 
 			clock := mockrepositories.NewClock(t)
-			clock.EXPECT().Now().Return(now).Once()
+			clock.EXPECT().UTCNow().Return(now).Once()
 
 			uuidgen := mockrepositories.NewUUIDGenerator(t)
 			uuidgen.EXPECT().NewV7().Return(id, nil).Once()

--- a/internal/usecases/update_resource.go
+++ b/internal/usecases/update_resource.go
@@ -35,7 +35,7 @@ func (u *UpdateResource) Execute(
 	store repositories.Resource,
 	changes *entities.Resource,
 ) (*entities.Resource, error) {
-	changes.Update(u.clock.Now())
+	changes.Update(u.clock.UTCNow())
 
 	resource, err := store.UpdateResource(ctx, changes)
 	if err != nil {

--- a/internal/usecases/update_resource_test.go
+++ b/internal/usecases/update_resource_test.go
@@ -31,7 +31,7 @@ func Test_UpdateResource_Success(t *testing.T) {
 	now := time.Now().UTC().Round(time.Second)
 
 	clock := mockrepositories.NewClock(t)
-	clock.EXPECT().Now().Return(now).Once()
+	clock.EXPECT().UTCNow().Return(now).Once()
 
 	usecase := usecases.NewUpdateResource(clock)
 	logger := slogt.New(t)
@@ -84,7 +84,7 @@ func Test_UpdateResource_Error(t *testing.T) {
 			now := time.Now().UTC().Round(time.Second)
 
 			clock := mockrepositories.NewClock(t)
-			clock.EXPECT().Now().Return(now).Once()
+			clock.EXPECT().UTCNow().Return(now).Once()
 
 			usecase := usecases.NewUpdateResource(clock)
 			logger := slogt.New(t)

--- a/mocks/domain/mockrepositories/mocks.go
+++ b/mocks/domain/mockrepositories/mocks.go
@@ -243,12 +243,12 @@ func (_m *Clock) EXPECT() *Clock_Expecter {
 	return &Clock_Expecter{mock: &_m.Mock}
 }
 
-// Now provides a mock function for the type Clock
-func (_mock *Clock) Now() time.Time {
+// LocalNow provides a mock function for the type Clock
+func (_mock *Clock) LocalNow() time.Time {
 	ret := _mock.Called()
 
 	if len(ret) == 0 {
-		panic("no return value specified for Now")
+		panic("no return value specified for LocalNow")
 	}
 
 	var r0 time.Time
@@ -260,29 +260,29 @@ func (_mock *Clock) Now() time.Time {
 	return r0
 }
 
-// Clock_Now_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Now'
-type Clock_Now_Call struct {
+// Clock_LocalNow_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'LocalNow'
+type Clock_LocalNow_Call struct {
 	*mock.Call
 }
 
-// Now is a helper method to define mock.On call
-func (_e *Clock_Expecter) Now() *Clock_Now_Call {
-	return &Clock_Now_Call{Call: _e.mock.On("Now")}
+// LocalNow is a helper method to define mock.On call
+func (_e *Clock_Expecter) LocalNow() *Clock_LocalNow_Call {
+	return &Clock_LocalNow_Call{Call: _e.mock.On("LocalNow")}
 }
 
-func (_c *Clock_Now_Call) Run(run func()) *Clock_Now_Call {
+func (_c *Clock_LocalNow_Call) Run(run func()) *Clock_LocalNow_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run()
 	})
 	return _c
 }
 
-func (_c *Clock_Now_Call) Return(time1 time.Time) *Clock_Now_Call {
+func (_c *Clock_LocalNow_Call) Return(time1 time.Time) *Clock_LocalNow_Call {
 	_c.Call.Return(time1)
 	return _c
 }
 
-func (_c *Clock_Now_Call) RunAndReturn(run func() time.Time) *Clock_Now_Call {
+func (_c *Clock_LocalNow_Call) RunAndReturn(run func() time.Time) *Clock_LocalNow_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -334,6 +334,50 @@ func (_c *Clock_Since_Call) Return(duration time.Duration) *Clock_Since_Call {
 }
 
 func (_c *Clock_Since_Call) RunAndReturn(run func(t time.Time) time.Duration) *Clock_Since_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UTCNow provides a mock function for the type Clock
+func (_mock *Clock) UTCNow() time.Time {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for UTCNow")
+	}
+
+	var r0 time.Time
+	if returnFunc, ok := ret.Get(0).(func() time.Time); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(time.Time)
+	}
+	return r0
+}
+
+// Clock_UTCNow_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UTCNow'
+type Clock_UTCNow_Call struct {
+	*mock.Call
+}
+
+// UTCNow is a helper method to define mock.On call
+func (_e *Clock_Expecter) UTCNow() *Clock_UTCNow_Call {
+	return &Clock_UTCNow_Call{Call: _e.mock.On("UTCNow")}
+}
+
+func (_c *Clock_UTCNow_Call) Run(run func()) *Clock_UTCNow_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Clock_UTCNow_Call) Return(time1 time.Time) *Clock_UTCNow_Call {
+	_c.Call.Return(time1)
+	return _c
+}
+
+func (_c *Clock_UTCNow_Call) RunAndReturn(run func() time.Time) *Clock_UTCNow_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
As discussed in [Monotonic and Wall Clock Time in the Go time package][1], `time.Now().UTC()` strips the monotonic component of `time.Time` making it unsuitable for calculating the duration between 2 points in time. To correct this the `repositories.Clock.Now` method has been renamed to `UTCNow` and a new `LocalNow` has been added to return `time.Time` with a monotonic component.

This does not impact the application as the `Since` and `Until` methods of `repositories.Clock` were unused, but it's a useful improvement regardless.

Fixes #408.

[1]: https://victoriametrics.com/blog/go-time-monotonic-wall-clock/