### PR TITLE
Upload trivy results to CodeQL

### DIFF
--- a/.github/actions/container-build/action.yml
+++ b/.github/actions/container-build/action.yml
@@ -46,9 +46,14 @@ runs:
         image-ref: ${{ inputs.repository }}:${{ inputs.version }}
         scan-type: image
         trivy-config: trivy.yaml
+        format: template
+        template: "@/contrib/sarif.tpl"
+        output: trivy-results.sarif
 
-    # TODO: publish to github for default branch builds
-    # https://github.com/actions/starter-workflows/blob/main/code-scanning/trivy.yml
+    - name: Upload Trivy scan results
+      uses: github/codeql-action/upload-sarif@51f77329afa6477de8c49fc9c7046c15b9a4e79d # v3.29.5
+      with:
+        sarif_file: trivy-results.sarif
 
     - name: Cosign
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,9 +188,14 @@ jobs:
           scan-type: fs
           trivy-config: trivy.yaml
           version: v${{ steps.trivy-version.outputs.tag }}
+          format: template
+          template: "@/contrib/sarif.tpl"
+          output: trivy-results.sarif
 
-      # TODO: publish to github for default branch builds?
-      # https://github.com/actions/starter-workflows/blob/main/code-scanning/trivy.yml
+      - name: Upload Trivy scan results
+        uses: github/codeql-action/upload-sarif@51f77329afa6477de8c49fc9c7046c15b9a4e79d # v3.29.5
+        with:
+          sarif_file: trivy-results.sarif
 
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@f52a838cfabf134edcbaa7c8b3677dde20045018 # v0.1.1

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -5,7 +5,7 @@
 db:
   repository: public.ecr.aws/aquasecurity/trivy-db:2
 
-exit-code: 1
+exit-code: 0
 ignorefile: .trivyignore.yaml
 ignore-policy: config/trivyignore.rego
 


### PR DESCRIPTION
- Upload Trivy scan results to CodeQL for filesystem and image scans.
- Configure Trivy to exit with 0 on failure so CodeQL can take ownership of failures.