### PR TITLE
Update k8smount koanf provider with Go 1.25 improvements

### DIFF
--- a/internal/drivers/config/providers/k8smount/helper_test.go
+++ b/internal/drivers/config/providers/k8smount/helper_test.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"testing"
 	"time"
 )
 
 const (
-	configmapTimeFmt = "2006_01_02_15_04_05.0000000000"
-	dataDir          = "..data"
+	mountTimeFmt = "..2006_01_02_15_04_05.0000000000"
+	dataDir      = "..data"
 )
 
 // writeVolumeMount creates a file structure that matches how a ConfigMap or Secret will be mounted
@@ -32,37 +33,62 @@ const (
 //	database.hostname -> ..data/database.hostname
 //	database.name -> ..data/database.name
 //	database.port -> ..data/database.port
-func writeVolumeMount(mount string, data map[string]string) error {
-	dir := time.Now().UTC().Format(configmapTimeFmt)
+func writeVolumeMount(tb testing.TB, mount string, data map[string]string) error {
+	tb.Helper()
 
+	return writeVolumeMountAtTime(tb, time.Now(), mount, data)
+}
+
+// writeVolumeMountAtTime creates a file structure that matches how a ConfigMap or Secret will be
+// mounted in a Kubernetes Pod, using the given time. See writeVolumeMount for a detailed
+// description of the resulting file structure.
+//
+// This function can be called multiple times with different times, with the most recent call taking
+// precedence if any conflicts occur.
+func writeVolumeMountAtTime(tb testing.TB, t time.Time, mount string, data map[string]string) error {
+	tb.Helper()
+
+	dir := t.UTC().Format(mountTimeFmt)
 	dirPath := filepath.Join(mount, dir)
 
 	for key, value := range data {
-		if err := writeFile(filepath.Join(dirPath, key), value); err != nil {
+		if err := writeFile(tb, filepath.Join(dirPath, key), value); err != nil {
 			return err
 		}
 	}
 
-	if err := os.Chdir(mount); err != nil {
-		return fmt.Errorf("failed to change dir to %q: %w", mount, err)
+	tb.Chdir(mount)
+
+	if err := os.Remove(dataDir); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to cleanup existing symlink %s: %w", dataDir, err)
 	}
 
-	if err := os.Symlink(dir, "..data"); err != nil {
+	if err := os.Symlink(dir, dataDir); err != nil {
 		return fmt.Errorf("failed to create %s symlink to %q: %w", "..data", dir, err)
 	}
+
+	tb.Log("created symlink: ..data ->", dir)
 
 	for key := range data {
 		target := filepath.Join(dataDir, key)
 
+		if err := os.Remove(key); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed to cleanup existing symlink %s: %w", key, err)
+		}
+
 		if err := os.Symlink(target, key); err != nil {
 			return fmt.Errorf("failed to create %q symlink to %q: %w", key, target, err)
 		}
+
+		tb.Log("created symlink:", key, "->", target)
 	}
 
 	return nil
 }
 
-func writeFile(path, content string) error {
+func writeFile(tb testing.TB, path, content string) error {
+	tb.Helper()
+
 	dir := filepath.Dir(path)
 
 	if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -73,7 +99,7 @@ func writeFile(path, content string) error {
 		return fmt.Errorf("failed to create file %q: %w", path, err)
 	}
 
-	fmt.Println("created:", path)
+	tb.Log("wrote:", path)
 
 	return nil
 }

--- a/internal/drivers/config/providers/k8smount/provider.go
+++ b/internal/drivers/config/providers/k8smount/provider.go
@@ -34,7 +34,7 @@ type K8SMount struct {
 // Provider creates a new K8SMount provider capable of reading in mounted secrets and configmaps in
 // a Kubernetes pod.
 //
-// The given path should be the mount point of the configmap or secret. The delimiter is used to
+// The given mount should be the mount point of the configmap or secret. The delimiter is used to
 // create a hierarchy of keys based on the mounted filename. For example, a configmap mounted at
 // "/mnt/config/" with a key of "log.level" set to "INFO" would result in {"log":{"level":"INFO"}}
 // being read as configuration.
@@ -61,40 +61,67 @@ func (k *K8SMount) Read() (map[string]any, error) {
 	mountFS := root.FS()
 
 	if err := fs.WalkDir(mountFS, ".", func(path string, d fs.DirEntry, err error) error {
+		key, content, err := k.walkDir(mountFS, path, d, err)
 		if err != nil {
 			return err
 		}
 
-		// skip sub-directories as path separators are invalid in keys
-		// FIXME: data can be mounted at paths depending on how the pod volume is configured
-		if d.IsDir() {
-			if path == "." {
-				return nil
-			}
-
-			return fs.SkipDir
+		if key != "" {
+			data[key] = content
 		}
-
-		// paths with a ".." prefix are reserved for the actual data files to be stored under
-		// instead of reading those, use symlinks in the root of the mount instead
-		if strings.HasPrefix(path, "..") {
-			return nil
-		}
-
-		content, err := fs.ReadFile(mountFS, path)
-		if err != nil {
-			return fmt.Errorf("failed to read file: %w", err)
-		}
-
-		key := strings.TrimPrefix(path, k.mount)
-		data[key] = string(content)
 
 		return nil
 	}); err != nil {
 		return nil, fmt.Errorf("failed to read configuration from mount: %q: %w", k.mount, err)
 	}
 
-	return maps.Unflatten(data, k.delim), nil
+	return maps.Unflatten(maps.Unflatten(data, k.delim), "/"), nil
+}
+
+//nolint:gocritic // named return vars don't make code much more readable
+func (k *K8SMount) walkDir(mountFS fs.FS, path string, d fs.DirEntry, err error) (string, string, error) {
+	if err != nil {
+		return "", "", err
+	}
+
+	if path == "." && d.IsDir() {
+		return "", "", nil
+	}
+
+	resolved := path
+
+	for d.Type()&os.ModeSymlink != 0 {
+		p, err := fs.ReadLink(mountFS, resolved)
+		if err != nil {
+			return "", "", err
+		}
+
+		info, err := fs.Lstat(mountFS, p)
+		if err != nil {
+			return "", "", err
+		}
+
+		d = fs.FileInfoToDirEntry(info)
+		resolved = p
+	}
+
+	if d.IsDir() {
+		// don't skip ..data as it causes the symlinks we want to look at to be skipped
+		// instead, just skip the timestamp based directories
+		if strings.HasPrefix(path, "..") && path != "..data" {
+			return "", "", fs.SkipDir
+		}
+
+		return "", "", nil
+	}
+
+	content, err := fs.ReadFile(mountFS, path)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to read file: %w", err)
+	}
+
+	key := strings.TrimPrefix(path, k.mount)
+	return key, string(content), nil
 }
 
 // Watch starts a watcher in a goroutine for the files under the mount point and calls the given
@@ -147,6 +174,7 @@ func (k *K8SMount) watchDir(fn func(err error)) {
 			lastEventTime = time.Now()
 
 			// mounts are only meant to be updated for the lifetime of the pod
+			// TODO: test what happens when we edit a configmap
 			if !event.Has(fsnotify.Write | fsnotify.Chmod) {
 				fn(fmt.Errorf("%w: %s", ErrUnexpectedEvent, event.String()))
 				return

--- a/internal/drivers/config/providers/k8smount/provider_test.go
+++ b/internal/drivers/config/providers/k8smount/provider_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -53,10 +54,10 @@ func Test_K8SMount_Read_WithFiles(t *testing.T) {
 	// arrange
 	dir := t.TempDir()
 
-	require.NoError(t, writeFile(filepath.Join(dir, "a"), "a"))
-	require.NoError(t, writeFile(filepath.Join(dir, "b.c"), "c"))
-	require.NoError(t, writeFile(filepath.Join(dir, "d.e.f"), "f"))
-	require.NoError(t, writeFile(filepath.Join(dir, "dir", "file"), "a")) // should be ignored
+	require.NoError(t, writeFile(t, filepath.Join(dir, "a"), "a"))
+	require.NoError(t, writeFile(t, filepath.Join(dir, "b.c"), "c"))
+	require.NoError(t, writeFile(t, filepath.Join(dir, "d.e.f"), "f"))
+	require.NoError(t, writeFile(t, filepath.Join(dir, "g", "h"), "h"))
 
 	provider := k8smount.Provider(dir, "." /*delim*/)
 
@@ -74,6 +75,9 @@ func Test_K8SMount_Read_WithFiles(t *testing.T) {
 				"f": "f",
 			},
 		},
+		"g": map[string]any{
+			"h": "h",
+		},
 	}
 
 	assert.Equal(t, want, got)
@@ -84,7 +88,44 @@ func Test_K8SMount_Read_WithVolumeMount(t *testing.T) {
 	// arrange
 	dir := t.TempDir()
 
-	require.NoError(t, writeVolumeMount(dir, map[string]string{
+	require.NoError(t, writeVolumeMount(t, dir, map[string]string{
+		"a.foo": "foo-value",
+		"b.bar": "bar-value",
+		"b.baz": "baz-value",
+	}))
+
+	provider := k8smount.Provider(dir, "." /*delim*/)
+
+	// act
+	got, err := provider.Read()
+
+	// assert
+	want := map[string]any{
+		"a": map[string]any{
+			"foo": "foo-value",
+		},
+		"b": map[string]any{
+			"bar": "bar-value",
+			"baz": "baz-value",
+		},
+	}
+
+	assert.Equal(t, want, got)
+	assert.NoError(t, err)
+}
+
+func Test_K8SMount_Read_WithVolumeMount_Changing(t *testing.T) {
+	// arrange
+	now := time.Now()
+	dir := t.TempDir()
+
+	require.NoError(t, writeVolumeMountAtTime(t, now.Add(time.Hour*1), dir, map[string]string{
+		"a.foo": "old-foo-value",
+		"b.bar": "old-bar-value",
+		"b.baz": "oldbaz-value",
+	}))
+
+	require.NoError(t, writeVolumeMountAtTime(t, now, dir, map[string]string{
 		"a.foo": "foo-value",
 		"b.bar": "bar-value",
 		"b.baz": "baz-value",
@@ -130,7 +171,7 @@ func Test_K8SMount_Watch_Success(t *testing.T) {
 	// arrange
 	dir := t.TempDir()
 
-	require.NoError(t, writeFile(filepath.Join(dir, "a"), "a"))
+	require.NoError(t, writeFile(t, filepath.Join(dir, "a"), "a"))
 
 	provider := k8smount.Provider(dir, "." /*delim*/)
 
@@ -146,7 +187,7 @@ func Test_K8SMount_Watch_Success(t *testing.T) {
 	}))
 
 	for !watched.Load() {
-		require.NoError(t, writeFile(filepath.Join(dir, "a"), "b"))
+		require.NoError(t, writeFile(t, filepath.Join(dir, "a"), "b"))
 	}
 
 	// assert
@@ -187,7 +228,7 @@ func Test_K8SMount_Watch_UnexpectedEvent(t *testing.T) {
 	// arrange
 	dir := t.TempDir()
 
-	require.NoError(t, writeFile(filepath.Join(dir, "a"), "a"))
+	require.NoError(t, writeFile(t, filepath.Join(dir, "a"), "a"))
 
 	provider := k8smount.Provider(dir, "." /*delim*/)
 


### PR DESCRIPTION
- Use Go 1.25 updates to `os.Root` to handle symlink resolution better.
- Handle files being mounted in subdirectories (not fully tested).