### PR TITLE
Create Tilt environment with observability charts

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -65,7 +65,7 @@ tilt-up:
 # Stop the development environment.
 [group('development environment')]
 tilt-down:
-    tilt-down
+    tilt down
 
 [private]
 _kind-up: install-kind install-ctlptl

--- a/.tilt/grafana/values.yaml
+++ b/.tilt/grafana/values.yaml
@@ -1,0 +1,39 @@
+---
+# https://github.com/grafana/helm-charts/blob/main/charts/grafana/README.md
+
+env:
+  GF_AUTH_ANONYMOUS_ENABLED: "true"
+  GF_AUTH_ANONYMOUS_ORG_ROLE: "Admin"
+  GF_AUTH_BASIC_ENABLED: "false"
+  GF_INSTALL_PLUGINS: "victoriametrics-metrics-datasource,victoriametrics-logs-datasource"
+
+datasources:
+  datasources.yaml:
+    apiVersion: 1
+    datasources:
+      - name: "VictoriaMetrics"
+        type: "victoriametrics-metrics-datasource"
+        uid: "victoriametrics"
+        url: "http://victoria-metrics-single-server.default.svc.cluster.local:8428/"
+        access: "proxy"
+        basicAuth: false
+        isDefault: true
+        editable: false
+
+      - name: "VictoriaLogs"
+        type: "victoriametrics-logs-datasource"
+        uid: "victorialogs"
+        url: "http://victoria-logs-single-server.default.svc.cluster.local:9428/"
+        access: "proxy"
+        basicAuth: false
+        isDefault: false
+        editable: false
+
+      - name: "Tempo"
+        type: "tempo"
+        uid: "tempo"
+        url: "http://tempo.default.svc.cluster.local:3200/"
+        access: "proxy"
+        basicAuth: false
+        isDefault: false
+        editable: false

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,0 +1,101 @@
+# https://docs.tilt.dev/api.html
+
+# -----
+# Setup
+# -----
+
+# Prevent tilt from accessing other clusters
+allow_k8s_contexts("kind-kind")
+
+# ----------
+# Extensions
+# ----------
+
+load("ext://helm_remote", "helm_remote")
+
+# --------------
+# Local services
+# --------------
+
+# TODO
+
+# --------
+# Database
+# --------
+
+# TODO
+
+# -------------
+# Observability
+# -------------
+
+helm_remote(
+    "tempo",
+    repo_name="grafana",
+    repo_url="https://grafana.github.io/helm-charts",
+    # TODO: version=
+)
+
+k8s_resource(
+    "tempo",
+    objects=[
+        "tempo:serviceaccount",
+        "tempo:configmap",
+    ],
+    labels=["observability"],
+)
+
+helm_remote(
+    "victoria-metrics-single",
+    repo_name="vm",
+    repo_url="https://victoriametrics.github.io/helm-charts",
+    # TODO: version=
+)
+
+k8s_resource(
+    "victoria-metrics-single-server",
+    objects=["victoria-metrics-single-server:serviceaccount"],
+    labels=["observability"],
+    port_forwards=["127.0.0.1:8428:8428"],
+)
+
+helm_remote(
+    "victoria-logs-single",
+    repo_name="vm",
+    repo_url="https://victoriametrics.github.io/helm-charts",
+    # TODO: version=
+)
+
+k8s_resource(
+    "victoria-logs-single-server",
+    labels=["observability"],
+    port_forwards=["127.0.0.1:9428:9428"],
+)
+
+helm_remote(
+    "grafana",
+    repo_name="grafana",
+    repo_url="https://grafana.github.io/helm-charts",
+    # TODO: version=
+    values=[".tilt/grafana/values.yaml"],
+)
+
+k8s_resource(
+    "grafana",
+    objects=[
+        "grafana:serviceaccount",
+        "grafana:role",
+        "grafana-clusterrole:clusterrole",
+        "grafana:rolebinding",
+        "grafana-clusterrolebinding:clusterrolebinding",
+        "grafana:configmap",
+        "grafana:secret",
+    ],
+    labels=["observability"],
+    port_forwards=["127.0.0.1:3000:3000"],
+    resource_deps=[
+        "tempo",
+        "victoria-metrics-single-server",
+        "victoria-logs-single-server",
+    ],
+)

--- a/Tiltfile
+++ b/Tiltfile
@@ -33,7 +33,8 @@ helm_remote(
     "tempo",
     repo_name="grafana",
     repo_url="https://grafana.github.io/helm-charts",
-    # TODO: version=
+    # renovate: datasource=helm depName=tempo packageName=grafana.github.io/helm-charts/tempo
+    version="1.23.3",
 )
 
 k8s_resource(
@@ -49,7 +50,8 @@ helm_remote(
     "victoria-metrics-single",
     repo_name="vm",
     repo_url="https://victoriametrics.github.io/helm-charts",
-    # TODO: version=
+    # renovate: datasource=helm depName=victoria-metrics-single packageName=victoriametrics.github.io/helm-charts/victoria-metrics-single
+    version="0.24.4",
 )
 
 k8s_resource(
@@ -63,7 +65,8 @@ helm_remote(
     "victoria-logs-single",
     repo_name="vm",
     repo_url="https://victoriametrics.github.io/helm-charts",
-    # TODO: version=
+    # renovate: datasource=helm depName=victoria-logs-single packageName=victoriametrics.github.io/helm-charts/victoria-logs-single
+    version="0.11.7",
 )
 
 k8s_resource(
@@ -76,7 +79,8 @@ helm_remote(
     "grafana",
     repo_name="grafana",
     repo_url="https://grafana.github.io/helm-charts",
-    # TODO: version=
+    # renovate: datasource=helm depName=grafana packageName=grafana.github.io/helm-charts/grafana
+    version="9.4.4",
     values=[".tilt/grafana/values.yaml"],
 )
 

--- a/renovate.json
+++ b/renovate.json
@@ -26,7 +26,7 @@
         "/^Tiltfile$/",
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>[a-zA-Z0-9-._]+?) depName=(?<depName>[^\\s]+?) packageName=(?<packageName>[^\\s]+?))\\s+version=[\"'](?<currentValue>.+?)[\"']"
+        "# renovate: datasource=(?<datasource>[a-zA-Z0-9._-]+?) depName=(?<depName>[^\\s]+?) packageName=(?<packageName>[^\\s]+?)\\s+version=['\"](?<currentValue>.+?)['\"]"
       ]
     },
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -18,5 +18,16 @@
       "groupName": "X-Repositories"
     }
   ],
-  "postUpdateOptions": ["gomodTidy", "goModVendor", "gomodUpdateImportPaths"]
+  "postUpdateOptions": ["gomodTidy", "goModVendor", "gomodUpdateImportPaths"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^Tiltfile$/",
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-zA-Z0-9-._]+?) depName=(?<depName>[^\\s]+?) packageName=(?<packageName>[^\\s]+?))\\s+version=[\"'](?<currentValue>.+?)[\"']"
+      ]
+    },
+  ]
 }


### PR DESCRIPTION
Initialise the `Tiltfile` with observability tooling, namely Tempo, VictoriaMetrics and VictoriaLogs. This is a slight divergence from the current use of Jaeger, but it gives us access to TraceQL. In the future, we may switch to VictoriaTraces for consistency.

The database and locally-developed services have been omitted at this time. Development of those can be found in #323.

This also includes a custom manager in Renovate to enable automatic updates to the charts. The correctness of this will be validated post-merge.