### PR TITLE
Fix renovate updates for Tilt charts

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -79,7 +79,7 @@ helm_remote(
     "grafana",
     repo_name="grafana",
     repo_url="https://grafana.github.io/helm-charts",
-    # renovate: datasource=helm depName=grafana packageName=grafana.github.io/helm-charts/grafana
+    # renovate: datasource=helm depName=grafana packageName=grafana registryUrl=grafana.github.io/helm-charts
     version="9.4.4",
     values=[".tilt/grafana/values.yaml"],
 )

--- a/renovate.json
+++ b/renovate.json
@@ -26,7 +26,7 @@
         "/^Tiltfile$/",
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>[a-zA-Z0-9._-]+?) depName=(?<depName>[^\\s]+?) packageName=(?<packageName>[^\\s]+?)\\s+version=['\"](?<currentValue>.+?)['\"]"
+        "# renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>.+?) packageName=(?<packageName>.+?) registryUrl=(?<registryUrl>.+?)\\s+version=['\"](?<currentValue>.+?)['\"]"
       ]
     },
   ]


### PR DESCRIPTION
The merge of #488 identified some errors with Renovate's ability to update helm chart versions in the Tiltfile. A search across github found the following example:

* Config: https://github.com/mitodl/ol-infrastructure/blob/e430fe40dbf324740ba46c88a264e44b79069cba/renovate.json5
* Usage: https://github.com/mitodl/ol-infrastructure/blob/e430fe40dbf324740ba46c88a264e44b79069cba/src/bridge/lib/versions.py#L22

This change includes a simplified version of the regex, the addition of the repositoryUrl and an adjusted packageName which will hopefully work.