### PR TITLE
Add schemes to registry URLs for renovate updates

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -33,7 +33,7 @@ helm_remote(
     "tempo",
     repo_name="grafana",
     repo_url="https://grafana.github.io/helm-charts",
-    # renovate: datasource=helm depName=tempo packageName=tempo registryUrl=grafana.github.io/helm-charts
+    # renovate: datasource=helm depName=tempo packageName=tempo registryUrl=https://grafana.github.io/helm-charts
     version="1.23.3",
 )
 
@@ -50,7 +50,7 @@ helm_remote(
     "victoria-metrics-single",
     repo_name="vm",
     repo_url="https://victoriametrics.github.io/helm-charts",
-    # renovate: datasource=helm depName=victoria-metrics-single packageName=victoria-metrics-single registryUrl=victoriametrics.github.io/helm-charts
+    # renovate: datasource=helm depName=victoria-metrics-single packageName=victoria-metrics-single registryUrl=https://victoriametrics.github.io/helm-charts
     version="0.24.4",
 )
 
@@ -65,7 +65,7 @@ helm_remote(
     "victoria-logs-single",
     repo_name="vm",
     repo_url="https://victoriametrics.github.io/helm-charts",
-    # renovate: datasource=helm depName=victoria-logs-single packageName=victoria-logs-single registryUrl=victoriametrics.github.io/helm-charts
+    # renovate: datasource=helm depName=victoria-logs-single packageName=victoria-logs-single registryUrl=https://victoriametrics.github.io/helm-charts
     version="0.11.7",
 )
 
@@ -79,7 +79,7 @@ helm_remote(
     "grafana",
     repo_name="grafana",
     repo_url="https://grafana.github.io/helm-charts",
-    # renovate: datasource=helm depName=grafana packageName=grafana registryUrl=grafana.github.io/helm-charts
+    # renovate: datasource=helm depName=grafana packageName=grafana registryUrl=https://grafana.github.io/helm-charts
     version="9.4.4",
     values=[".tilt/grafana/values.yaml"],
 )


### PR DESCRIPTION
Add missing schemes to the registry URLs used by Renovate for helm chart updates.