### PR TITLE
Use underscores for splitting configmap fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,22 +30,27 @@ A toy Go microservice intended for use as reference material.
 # ready: success
 echo '{}' | grpc-client-cli -a localhost:5000 -s Health -m Check
 
+# login
+echo '{"id":"example","secret":"example"}' | grpc-client-cli -a localhost:5000 -s AuthnService -m Login
+
+token=`echo '{"id":"example","secret":"example"}' | \
+  grpc-client-cli -a localhost:5000 -s AuthnService -m Login | \
+  jq -r '.access_token'`
+
+# authenticate
+echo "{\"token\":\"${token>}\"}" | grpc-client-cli -a localhost:5000 -s AuthnService -m Authenticate
+
 # create: success
 echo '{"resource":{"name":"example"}}' | \
-	grpc-client-cli -a localhost:5000 -s ExampleService -m CreateResource
+	grpc-client-cli -a localhost:5000 -s ExampleService -m CreateResource -H "Authorization: Bearer $token"
 
 # create: success (bulk)
 for i in {1..100}; do
 	echo "{\"resource\":{\"name\":\"example-$i\"}}" | \
-		grpc-client-cli -a localhost:5000 -s ExampleService -m CreateResource
+		grpc-client-cli -a localhost:5000 -s ExampleService -m CreateResource -H "Authorization: Bearer $token"
 done
 
 # list: success
-echo '{}' | grpc-client-cli -a localhost:5000 -s ExampleService -m ListResources
+echo '{}' | grpc-client-cli -a localhost:5000 -s ExampleService -m ListResources -H "Authorization: Bearer $token"
 
-# login
-echo '{"id":"example","secret":"example"}' | grpc-client-cli -a localhost:5000 -s AuthnService -m Login
-
-# authenticate
-echo '{"token":"<token>"}' | grpc-client-cli -a localhost:5000 -s AuthnService -m Authenticate
 ```

--- a/internal/drivers/config/config.go
+++ b/internal/drivers/config/config.go
@@ -16,7 +16,7 @@ import (
 	"github.com/mattdowdell/sandbox/internal/drivers/config/providers/k8smount"
 )
 
-// The delimiter to use for splitting and joining configuration keys.
+// The delimiter to use for joining configuration keys.
 const (
 	delimiter = "."
 )
@@ -24,9 +24,9 @@ const (
 // Options provides the values to bootstrap configuration collection.
 type Options struct {
 	// The prefix of environment variables to read configuration from. Matching environment
-	// variables have the prefix removed, are converted to lowercase and any underscores are
-	// replaced with ".". For example, "APP_LOG_LEVEL" with a prefix of "APP_" would become
-	// "log.level".
+	// variables have the prefix removed, are converted to lowercase and any underscores ("_") are
+	// replaced with periods ("."). For example, "APP_LOG_LEVEL" with a prefix of "APP_" would
+	// become "log.level".
 	EnvPrefix string
 
 	// The file paths to read configuration from. Supported file formats and extensions are:
@@ -40,8 +40,8 @@ type Options struct {
 	Files []string
 
 	// The directories of Kubernetes pod mounts to read configuration from. The filenames of the
-	// mounted values become the configuration keys. For example, a configmap field of "log.level"
-	// can be accessed at the same name.
+	// mounted values become the configuration keys. Any underscores ("_") in the key are replaced
+	// with periods ("."). For example, a configmap field of "log_level" would become "log.level".
 	Mounts []string
 }
 
@@ -149,7 +149,7 @@ func (c *Config[T]) loadFiles() error {
 
 func (c *Config[T]) loadMounts() error {
 	for _, path := range c.opts.Mounts {
-		if err := c.inner.Load(k8smount.Provider(path, delimiter), nil); err != nil {
+		if err := c.inner.Load(k8smount.Provider(path, "_" /*delimiter*/), nil); err != nil {
 			return err
 		}
 	}

--- a/internal/drivers/config/splitter/splitters.go
+++ b/internal/drivers/config/splitter/splitters.go
@@ -1,4 +1,5 @@
-// ...
+// Package splitter provides unmarshalers for Koanf config structs to convert strings to string
+// slices using a particular delimiter.
 package splitter
 
 import (
@@ -12,30 +13,36 @@ var (
 	_ encoding.TextUnmarshaler = (*Space)(nil)
 )
 
-// ...
+// Comma unmarshals a string into a slice of strings using a comma as a delimiter.
 type Comma []string
 
 // ...
 func (c *Comma) UnmarshalText(text []byte) error {
-	*c = strings.Split(string(text), ",")
+	if len(text) > 0 {
+		*c = strings.Split(string(text), ",")
+	}
+
 	return nil
 }
 
-// ...
+// Unwrap returns the underlying string slice after unmarshaling.
 func (c *Comma) Unwrap() []string {
 	return []string(*c)
 }
 
-// ...
+// Comma unmarshals a string into a slice of strings using a space as a delimiter.
 type Space []string
 
 // ...
 func (s *Space) UnmarshalText(text []byte) error {
-	*s = strings.Split(string(text), " ")
+	if len(text) > 0 {
+		*s = strings.Split(string(text), " ")
+	}
+
 	return nil
 }
 
-// ...
+// Unwrap returns the underlying string slice after unmarshaling.
 func (s *Space) Unwrap() []string {
 	return []string(*s)
 }

--- a/internal/drivers/config/splitter/splitters_test.go
+++ b/internal/drivers/config/splitter/splitters_test.go
@@ -15,27 +15,69 @@ type MyConfig struct {
 }
 
 func Test_Comma_UnmarshalText(t *testing.T) {
-	// arrange
-	c := splitter.Comma{}
+	testCases := []struct {
+		name string
+		have string
+		want []string
+	}{
+		{
+			name: "empty",
+			have: "",
+			want: []string{},
+		},
+		{
+			name: "non-empty",
+			have: "foo,bar,baz",
+			want: []string{"foo", "bar", "baz"},
+		},
+	}
 
-	// act
-	err := c.UnmarshalText([]byte("foo,bar,baz"))
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// arrange
+			c := splitter.Comma{}
 
-	// assert
-	assert.Equal(t, []string{"foo", "bar", "baz"}, c.Unwrap())
-	assert.NoError(t, err)
+			// act
+			err := c.UnmarshalText([]byte(tc.have))
+
+			// assert
+			assert.Equal(t, tc.want, c.Unwrap())
+			assert.NoError(t, err)
+		})
+	}
 }
 
 func Test_Space_UnmarshalText(t *testing.T) {
-	// arrange
-	s := splitter.Space{}
+	testCases := []struct {
+		name string
+		have string
+		want []string
+	}{
+		{
+			name: "empty",
+			have: "",
+			want: []string{},
+		},
+		{
+			name: "non-empty",
+			have: "foo bar baz",
+			want: []string{"foo", "bar", "baz"},
+		},
+	}
 
-	// act
-	err := s.UnmarshalText([]byte("foo bar baz"))
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// arrange
+			s := splitter.Space{}
 
-	// assert
-	assert.Equal(t, []string{"foo", "bar", "baz"}, s.Unwrap())
-	assert.NoError(t, err)
+			// act
+			err := s.UnmarshalText([]byte(tc.have))
+
+			// assert
+			assert.Equal(t, tc.want, s.Unwrap())
+			assert.NoError(t, err)
+		})
+	}
 }
 
 func Test_Load(t *testing.T) {


### PR DESCRIPTION
While working on dynamically generating a ConfigMap using Helm's templating functionality, I realised that the period delimited keys in ConfigMaps is somewhat unnecessary. For environment variables we unconditionally split on underscores, and so it seems more consistent to match that precedent and do the same in ConfigMap and Secret volume mounts.

Full changes:

- Update sanity checks in README to include authentication.
- Change the delimiter for splitting volume mount fields from periods to underscores.
- Fully document the config splitters package.
- Convert an empty string to an empty slice in the splitter package and add unit tests to validate the behaviour.