### PR TITLE
Add comments for use of non-default workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: write
+      contents: read # for checkout
+      pull-requests: write # for adding labels to PRs
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -49,7 +49,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: read # for checkout
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -87,7 +87,7 @@ jobs:
       - checks
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: read # for checkout
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -126,7 +126,7 @@ jobs:
       - checks
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: read # for checkout
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -156,8 +156,8 @@ jobs:
       - checks
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      security-events: write
+      contents: read # for checkout
+      security-events: write # for uploading code scanning results
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -213,7 +213,7 @@ jobs:
       - scan
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: read # for checkout
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -273,7 +273,7 @@ jobs:
     needs:
       - functional
     permissions:
-      contents: write
+      contents: write # for pushing tags (and checkout)
     runs-on: ubuntu-latest
     outputs:
       short: ${{ steps.tag.outputs.short }}

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -12,7 +12,7 @@ jobs:
   packages:
     name: Packages
     permissions:
-      packages: write
+      packages: write # to delete stale packages
     runs-on: "ubuntu-latest"
     steps:
       - name: Cleanup old packages


### PR DESCRIPTION
This resolves the 4 code scanning issues currently reported by zizmor.