### PR TITLE
Create herd package with migration implementation

### DIFF
--- a/pkg/herd/doc.go
+++ b/pkg/herd/doc.go
@@ -1,0 +1,2 @@
+// Package herd provides support for running migrations against a PostgreSQL database.
+package herd

--- a/pkg/herd/file_migration.go
+++ b/pkg/herd/file_migration.go
@@ -1,0 +1,101 @@
+package herd
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// Non-allocation compile-time check for interface compliance.
+var _ Migration = (*FileMigration)(nil)
+
+// FileMigration uses the contents of a SQL file as a migration.
+type FileMigration struct {
+	version  int64
+	contents string
+}
+
+// CollectFileMigrations walks the filesystem, searching for files with a ".sql" extension. For each
+// found file, NewFileMigrationFromFS is called to create the migration.
+func CollectFileMigrations(filesystem fs.FS) ([]Migration, error) {
+	var migrations []Migration
+
+	if err := fs.WalkDir(filesystem, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		if filepath.Ext(path) != ".sql" {
+			return nil
+		}
+
+		migration, err := NewFileMigrationFromFS(filesystem, path)
+		if err != nil {
+			return err
+		}
+
+		migrations = append(migrations, migration)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return migrations, nil
+}
+
+// NewFileMigrationFromFS reads the file at the path from the filesystem. The last element of the
+// path is taken as the filename, and is passed with the contents to NewFileMigrationFromFilename.
+func NewFileMigrationFromFS(filesystem fs.FS, path string) (*FileMigration, error) {
+	contents, err := fs.ReadFile(filesystem, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read migration from filesystem: %w", err)
+	}
+
+	return NewFileMigrationFromFilename(filepath.Base(path), string(contents))
+}
+
+// NewFileMigrationFromFilename extracts the migration version from the given filename and calls
+// NewFileMigration.
+//
+// The version must be at the start of the filename followed by a underscore ("_"). For example,
+// 1_initial.sql would have a version of 1. Versions can be padded with 0s to make them easier to
+// view in a file browser. 0001_initial.sql and 1_initial.sql would have the same version.
+func NewFileMigrationFromFilename(filename, contents string) (*FileMigration, error) {
+	version, _, ok := strings.Cut(filename, "_")
+	if !ok {
+		return nil, fmt.Errorf("could not extract version from filename: %s", filename)
+	}
+
+	parsed, err := strconv.ParseInt(version, 10 /*base*/, 64 /*bitSize*/)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse version from filename %s: %w", filename, err)
+	}
+
+	return NewFileMigration(parsed, contents), nil
+}
+
+// NewFileMigration creates a new FileMigration.
+func NewFileMigration(version int64, contents string) *FileMigration {
+	return &FileMigration{
+		version:  version,
+		contents: contents,
+	}
+}
+
+// Version returns the migration version.
+func (m *FileMigration) Version() int64 {
+	return m.version
+}
+
+// Migrate executes the SQL file contents against the database.
+func (m *FileMigration) Migrate(ctx context.Context, db DB) error {
+	_, err := db.ExecContext(ctx, m.contents)
+	return err
+}

--- a/pkg/herd/file_migration_test.go
+++ b/pkg/herd/file_migration_test.go
@@ -1,0 +1,93 @@
+package herd_test
+
+import (
+	"database/sql/driver"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mattdowdell/sandbox/pkg/herd"
+)
+
+func collectVersions(migrations []herd.Migration) []int64 {
+	versions := make([]int64, 0, len(migrations))
+	for _, migration := range migrations {
+		versions = append(versions, migration.Version())
+	}
+
+	slices.Sort(versions)
+	return versions
+}
+
+func Test_CollectFileMigrations_Success(t *testing.T) {
+	// arrange
+	dir := t.TempDir()
+
+	writeFile(t, filepath.Join(dir, "1_initial.sql"))
+	writeFile(t, filepath.Join(dir, "0002_next.sql"))
+	writeFile(t, filepath.Join(dir, "3_ignored.txt"))
+	writeFile(t, filepath.Join(dir, "4_non-sequential.sql"))
+
+	filesystem := openRootFS(t, dir)
+
+	// act
+	migrations, err := herd.CollectFileMigrations(filesystem)
+
+	// assert
+	if assert.Len(t, migrations, 3) {
+		versions := collectVersions(migrations)
+		assert.Equal(t, []int64{1, 2, 4}, versions)
+	}
+
+	assert.NoError(t, err)
+}
+
+func Test_CollectFileMigrations_Error(t *testing.T) {
+	tests := map[string]struct {
+		filename string
+		want     string
+	}{
+		"undetectable version": {
+			filename: "1.sql",
+			want:     "could not extract version from filename: 1.sql",
+		},
+		"invalid version": {
+			filename: "invalid_initial.sql",
+			want: `could not parse version from filename invalid_initial.sql: ` +
+				`strconv.ParseInt: parsing "invalid": invalid syntax`,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			// arrange
+			dir := t.TempDir()
+			writeFile(t, filepath.Join(dir, tt.filename))
+
+			filesystem := openRootFS(t, dir)
+
+			// act
+			migrations, err := herd.CollectFileMigrations(filesystem)
+
+			// assert
+			assert.Empty(t, migrations)
+			assert.EqualError(t, err, tt.want)
+		})
+	}
+}
+
+func Test_FileMigration_Migrate(t *testing.T) {
+	// arrange
+	migration := herd.NewFileMigration(1, "-- example")
+
+	db, mock := newMockDB(t)
+	mock.ExpectExec("-- example").WillReturnResult(driver.ResultNoRows)
+
+	// act
+	err := migration.Migrate(t.Context(), db)
+
+	// assert
+	assert.NoError(t, err)
+}

--- a/pkg/herd/helpers_test.go
+++ b/pkg/herd/helpers_test.go
@@ -1,0 +1,44 @@
+package herd_test
+
+import (
+	"database/sql"
+	"io/fs"
+	"os"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newMockDB is used to create mocks for database queries.
+func newMockDB(t *testing.T) (*sql.DB, sqlmock.Sqlmock) {
+	t.Helper()
+
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	return db, mock
+}
+
+// ...
+func writeFile(t *testing.T, path string) {
+	t.Helper()
+
+	err := os.WriteFile(path, nil, 0o600)
+	require.NoErrorf(t, err, "failed to create file: %s", path)
+}
+
+// ...
+func openRootFS(t *testing.T, dir string) fs.FS {
+	t.Helper()
+
+	root, err := os.OpenRoot(dir)
+	require.NoError(t, err)
+
+	return root.FS()
+}

--- a/pkg/herd/migration.go
+++ b/pkg/herd/migration.go
@@ -1,0 +1,23 @@
+package herd
+
+import (
+	"context"
+	"database/sql"
+)
+
+// DB contains the methods from [sql.DB] that migrations can use.
+type DB interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+// Migration implementations apply schema or data changes to a database.
+type Migration interface {
+	// Version returns the migration version. It must be greater than 0 and unique across all
+	// migrations.
+	Version() int64
+
+	// Migrate applies the schema or data changes for the migration.
+	Migrate(context.Context, DB) error
+}

--- a/pkg/herd/testdata/0001_initial.sql
+++ b/pkg/herd/testdata/0001_initial.sql
@@ -1,0 +1,1 @@
+-- example

--- a/pkg/herd/testdata/example_test.go
+++ b/pkg/herd/testdata/example_test.go
@@ -1,0 +1,17 @@
+package herd_test
+
+import (
+	"embed"
+
+	"github.com/mattdowdell/sandbox/pkg/herd"
+)
+
+//go:embed testdata/*.sql
+var migrationFS embed.FS
+
+func Example() {
+	migrations, _ := herd.CollectFileMigrations(migrationFS)
+
+	// TODO: use migrations
+	_ = migrations
+}


### PR DESCRIPTION
- Create a herd package for support for PostgreSQL database migrations.
- Add a `Migration` interface and `FileMigration` implementation.