### PR TITLE
Add a migrator to herd

### DIFF
--- a/pkg/herd/internal_test.go
+++ b/pkg/herd/internal_test.go
@@ -1,0 +1,19 @@
+package herd
+
+// Exports to support unit tests.
+const (
+	TableNameSystem = tableNameSystem
+	TableNameUser   = tableNameUser
+
+	SystemVersionQuery = systemVersionQuery
+	UserVersionQuery   = userVersionQuery
+
+	SystemRecordQuery = systemRecordQuery
+	UserRecordQuery   = userRecordQuery
+)
+
+// Exports to support unit tests.
+var (
+	NewMigrator = newMigrator
+	NewRecorder = newRecorder
+)

--- a/pkg/herd/migrator.go
+++ b/pkg/herd/migrator.go
@@ -1,0 +1,109 @@
+package herd
+
+import (
+	"cmp"
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"slices"
+)
+
+// Result contains the migration version before and after the pending migrations were applied.
+type Result struct {
+	// Before is the migration version before applying any migrations. A value of 0 indicates that
+	// no migrations had been applied previously.
+	Before int64
+
+	// After is the migration version after applying any migrations. After will equal Before when no
+	// pending migrations were found.
+	After int64
+}
+
+// migrator applies system or user-defined migrations to the database.
+type migrator struct {
+	migrations []Migration
+	recorder   *recorder
+}
+
+// newMigrator creates a new migrator.
+func newMigrator(migrations []Migration, rec *recorder) (*migrator, error) {
+	slices.SortFunc(migrations, func(a, b Migration) int {
+		return cmp.Compare(a.Version(), b.Version())
+	})
+
+	for i, m := range migrations {
+		if m.Version() < 1 {
+			return nil, fmt.Errorf("migration version must be > 0, found: %d", m.Version())
+		}
+
+		// rely on sorting to detect duplicates
+		if i > 0 && m.Version() == migrations[i-1].Version() {
+			return nil, fmt.Errorf("duplicate migration version found: %d", m.Version())
+		}
+	}
+
+	return &migrator{
+		migrations: migrations,
+		recorder:   rec,
+	}, nil
+}
+
+// migrate applies pending migrations to the database.
+func (m *migrator) Migrate(
+	ctx context.Context,
+	db *sql.DB,
+	herdVersion int64,
+) (result *Result, err error) {
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+
+	// If we call Commit before Rollback, an atomic bool is flipped, Rollback will always return
+	// sql.ErrTxDone and the driver's rollback implementation is never called. This occurs
+	// regardless of whether Commit failed.
+	defer func() {
+		if err2 := tx.Rollback(); err2 != nil && !errors.Is(err2, sql.ErrTxDone) {
+			err = errors.Join(err, fmt.Errorf("failed to rollback transaction: %w", err2))
+		}
+	}()
+
+	before, err := m.recorder.GetCurrentVersion(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+
+	pending := slices.DeleteFunc(slices.Clone(m.migrations), func(m Migration) bool {
+		return m.Version() <= before
+	})
+
+	for _, migration := range pending {
+		if err := migration.Migrate(ctx, tx); err != nil {
+			return nil, fmt.Errorf("failed to apply migration %d: %w", migration.Version(), err)
+		}
+
+		if err := m.recorder.RecordMigration(
+			ctx,
+			tx,
+			migration.Version(),
+			herdVersion,
+		); err != nil {
+			return nil, fmt.Errorf("failed to record migration %d: %w", migration.Version(), err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	after := before
+	if len(pending) > 0 {
+		after = pending[len(pending)-1].Version()
+	}
+
+	return &Result{
+		Before: before,
+		After:  after,
+	}, nil
+}

--- a/pkg/herd/migrator_test.go
+++ b/pkg/herd/migrator_test.go
@@ -1,0 +1,351 @@
+package herd_test
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattdowdell/sandbox/mocks/domain/mockrepositories"
+	"github.com/mattdowdell/sandbox/pkg/herd"
+)
+
+const (
+	testCodeVersion      = "v0.0.1"
+	testCodeRevision     = "abcdef0123456789"
+	testHerdVersion      = 1
+	testMigrationVersion = 2
+	testMigration        = "-- example"
+)
+
+var testQueryRows = []string{"migration_version"}
+
+func Test_newMigrator_Success(t *testing.T) {
+	tests := map[string]struct {
+		have []herd.Migration
+	}{
+		"empty": {},
+		"single": {
+			have: []herd.Migration{
+				herd.NewFileMigration(1, ""),
+			},
+		},
+		"multiple sequential": {
+			have: []herd.Migration{
+				herd.NewFileMigration(1, ""),
+				herd.NewFileMigration(2, ""),
+				herd.NewFileMigration(3, ""),
+			},
+		},
+		"multiple non-sequential": {
+			have: []herd.Migration{
+				herd.NewFileMigration(5, ""),
+				herd.NewFileMigration(10, ""),
+				herd.NewFileMigration(15, ""),
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			// arrange
+			clock := mockrepositories.NewClock(t)
+			recorder := herd.NewRecorder(clock, herd.TableNameUser, testCodeVersion, testCodeRevision)
+
+			// act
+			migrator, err := herd.NewMigrator(tt.have, recorder)
+
+			// assert
+			assert.NotNil(t, migrator)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func Test_newMigrator_Error(t *testing.T) {
+	tests := map[string]struct {
+		have []herd.Migration
+		want string
+	}{
+		"non-positive version": {
+			have: []herd.Migration{
+				herd.NewFileMigration(0, ""),
+			},
+			want: "migration version must be > 0, found: 0",
+		},
+		"duplicate versions": {
+			have: []herd.Migration{
+				herd.NewFileMigration(1, ""),
+				herd.NewFileMigration(2, ""),
+				herd.NewFileMigration(3, ""),
+				herd.NewFileMigration(1, ""),
+			},
+			want: "duplicate migration version found: 1",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			// arrange
+			clock := mockrepositories.NewClock(t)
+			recorder := herd.NewRecorder(clock, herd.TableNameUser, testCodeVersion, testCodeRevision)
+
+			// act
+			migrator, err := herd.NewMigrator(tt.have, recorder)
+
+			// assert
+			assert.Nil(t, migrator)
+			assert.EqualError(t, err, tt.want)
+		})
+	}
+}
+
+func Test_migrator_Migrate_Success(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	tests := map[string]struct {
+		migrations []herd.Migration
+		db         func(*testing.T) *sql.DB
+		want       *herd.Result
+	}{
+		"empty migrations, unmigrated db": {
+			migrations: []herd.Migration{},
+			db: func(t *testing.T) *sql.DB {
+				t.Helper()
+
+				db, mock := newMockDB(t)
+				mock.ExpectBegin()
+				mock.ExpectQuery(herd.UserVersionQuery).WillReturnRows(sqlmock.NewRows(testQueryRows))
+				mock.ExpectCommit()
+
+				return db
+			},
+			want: &herd.Result{},
+		},
+		"no pending migrations, migrated db": {
+			migrations: []herd.Migration{
+				herd.NewFileMigration(testMigrationVersion, testMigration),
+			},
+			db: func(t *testing.T) *sql.DB {
+				t.Helper()
+
+				db, mock := newMockDB(t)
+				mock.ExpectBegin()
+				mock.ExpectQuery(herd.UserVersionQuery).
+					WillReturnRows(sqlmock.NewRows(testQueryRows).AddRow(testMigrationVersion))
+				mock.ExpectCommit()
+
+				return db
+			},
+			want: &herd.Result{
+				Before: testMigrationVersion,
+				After:  testMigrationVersion,
+			},
+		},
+		"pending migrations, unmigrated db": {
+			migrations: []herd.Migration{
+				herd.NewFileMigration(testMigrationVersion, testMigration),
+			},
+			db: func(t *testing.T) *sql.DB {
+				t.Helper()
+
+				db, mock := newMockDB(t)
+				mock.ExpectBegin()
+				mock.ExpectQuery(herd.UserVersionQuery).WillReturnRows(sqlmock.NewRows(testQueryRows))
+				mock.ExpectExec(testMigration).WillReturnResult(driver.ResultNoRows)
+				mock.ExpectExec(herd.UserRecordQuery).
+					WithArgs(testMigrationVersion, now, testCodeVersion, testCodeRevision, testHerdVersion).
+					WillReturnResult(driver.ResultNoRows)
+				mock.ExpectCommit()
+
+				return db
+			},
+			want: &herd.Result{
+				Before: 0,
+				After:  testMigrationVersion,
+			},
+		},
+		"pending migrations, partially migrated db": {
+			migrations: []herd.Migration{
+				herd.NewFileMigration(testMigrationVersion, testMigration),
+			},
+			db: func(t *testing.T) *sql.DB {
+				t.Helper()
+
+				db, mock := newMockDB(t)
+				mock.ExpectBegin()
+				mock.ExpectQuery(herd.UserVersionQuery).
+					WillReturnRows(sqlmock.NewRows(testQueryRows).AddRow(1))
+				mock.ExpectExec(testMigration).WillReturnResult(driver.ResultNoRows)
+				mock.ExpectExec(herd.UserRecordQuery).
+					WithArgs(testMigrationVersion, now, testCodeVersion, testCodeRevision, testHerdVersion).
+					WillReturnResult(driver.ResultNoRows)
+				mock.ExpectCommit()
+
+				return db
+			},
+			want: &herd.Result{
+				Before: 1,
+				After:  testMigrationVersion,
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			// arrange
+			clock := mockrepositories.NewClock(t)
+			clock.EXPECT().Now().Return(now).Maybe()
+
+			recorder := herd.NewRecorder(clock, herd.TableNameUser, testCodeVersion, testCodeRevision)
+
+			migrator, err := herd.NewMigrator(tt.migrations, recorder)
+			require.NoError(t, err)
+
+			db := tt.db(t)
+
+			// act
+			result, err := migrator.Migrate(t.Context(), db, testHerdVersion)
+
+			// assert
+			assert.Equal(t, tt.want, result)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func Test_migrator_Migrate_Error(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	tests := map[string]struct {
+		migrations []herd.Migration
+		db         func(*testing.T) *sql.DB
+		want       string
+	}{
+		"begin transaction": {
+			migrations: []herd.Migration{},
+			db: func(t *testing.T) *sql.DB {
+				t.Helper()
+
+				db, mock := newMockDB(t)
+				mock.ExpectBegin().WillReturnError(errors.New("begin error"))
+
+				return db
+			},
+			want: "failed to begin transaction: begin error",
+		},
+		"get current version": {
+			migrations: []herd.Migration{},
+			db: func(t *testing.T) *sql.DB {
+				t.Helper()
+
+				db, mock := newMockDB(t)
+				mock.ExpectBegin()
+				mock.ExpectQuery(herd.UserVersionQuery).WillReturnError(errors.New("query error"))
+				mock.ExpectRollback()
+
+				return db
+			},
+			want: "failed to scan current migration version: query error",
+		},
+		"apply migration": {
+			migrations: []herd.Migration{
+				herd.NewFileMigration(testMigrationVersion, testMigration),
+			},
+			db: func(t *testing.T) *sql.DB {
+				t.Helper()
+
+				db, mock := newMockDB(t)
+				mock.ExpectBegin()
+				mock.ExpectQuery(herd.UserVersionQuery).WillReturnRows(sqlmock.NewRows(testQueryRows))
+				mock.ExpectExec(testMigration).WillReturnError(errors.New("exec error"))
+				mock.ExpectRollback()
+
+				return db
+			},
+			want: "failed to apply migration 2: exec error",
+		},
+		"record migration": {
+			migrations: []herd.Migration{
+				herd.NewFileMigration(testMigrationVersion, testMigration),
+			},
+			db: func(t *testing.T) *sql.DB {
+				t.Helper()
+
+				db, mock := newMockDB(t)
+				mock.ExpectBegin()
+				mock.ExpectQuery(herd.UserVersionQuery).WillReturnRows(sqlmock.NewRows(testQueryRows))
+				mock.ExpectExec(testMigration).WillReturnResult(driver.ResultNoRows)
+				mock.ExpectExec(herd.UserRecordQuery).WillReturnError(errors.New("exec error"))
+				mock.ExpectRollback()
+
+				return db
+			},
+			want: "failed to record migration 2: exec error",
+		},
+		"commit": {
+			migrations: []herd.Migration{
+				herd.NewFileMigration(testMigrationVersion, testMigration),
+			},
+			db: func(t *testing.T) *sql.DB {
+				t.Helper()
+
+				db, mock := newMockDB(t)
+				mock.ExpectBegin()
+				mock.ExpectQuery(herd.UserVersionQuery).WillReturnRows(sqlmock.NewRows(testQueryRows))
+				mock.ExpectExec(testMigration).WillReturnResult(driver.ResultNoRows)
+				mock.ExpectExec(herd.UserRecordQuery).WillReturnResult(driver.ResultNoRows)
+				mock.ExpectCommit().WillReturnError(errors.New("commit error"))
+
+				return db
+			},
+			want: "failed to commit transaction: commit error",
+		},
+		"rollback": {
+			migrations: []herd.Migration{
+				herd.NewFileMigration(testMigrationVersion, testMigration),
+			},
+			db: func(t *testing.T) *sql.DB {
+				t.Helper()
+
+				db, mock := newMockDB(t)
+				mock.ExpectBegin()
+				mock.ExpectQuery(herd.UserVersionQuery).WillReturnRows(sqlmock.NewRows(testQueryRows))
+				mock.ExpectExec(testMigration).WillReturnResult(driver.ResultNoRows)
+				mock.ExpectExec(herd.UserRecordQuery).WillReturnError(errors.New("exec error"))
+				mock.ExpectRollback().WillReturnError(errors.New("rollback error"))
+
+				return db
+			},
+			want: "failed to record migration 2: exec error\n" +
+				"failed to rollback transaction: rollback error",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			// arrange
+			clock := mockrepositories.NewClock(t)
+			clock.EXPECT().Now().Return(now).Maybe()
+
+			recorder := herd.NewRecorder(clock, herd.TableNameUser, testCodeVersion, testCodeRevision)
+
+			migrator, err := herd.NewMigrator(tt.migrations, recorder)
+			require.NoError(t, err)
+
+			db := tt.db(t)
+
+			// act
+			result, err := migrator.Migrate(t.Context(), db, testHerdVersion)
+
+			// assert
+			assert.Nil(t, result)
+			assert.EqualError(t, err, tt.want)
+		})
+	}
+}

--- a/pkg/herd/recorder.go
+++ b/pkg/herd/recorder.go
@@ -1,0 +1,139 @@
+package herd
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+)
+
+const (
+	tableNameSystem = "herd_system_migrations"
+	tableNameUser   = "herd_user_migrations"
+)
+
+const (
+	systemVersionQuery = "SELECT migration_version FROM herd_system_migrations " +
+		"ORDER BY migration_version DESC LIMIT 1;"
+	userVersionQuery = "SELECT migration_version FROM herd_user_migrations " +
+		"ORDER BY migration_version DESC LIMIT 1;"
+
+	systemRecordQuery = "INSERT INTO herd_system_migrations " +
+		"(migration_version, migrated_at, code_version, code_revision) " +
+		"VALUES($1, $2, $3, $4);"
+	userRecordQuery = "INSERT INTO herd_user_migrations " +
+		"(migration_version, migrated_at, code_version, code_revision, herd_version) " +
+		"VALUES($1, $2, $3, $4, $5, $6);"
+)
+
+// Clock is used to record when a migration was applied.
+type Clock interface {
+	Now() time.Time
+}
+
+// recorder provides a table agnostic set of helpers for recording applied migrations.
+type recorder struct {
+	clock        Clock
+	tableName    string
+	codeVersion  string
+	codeRevision string
+}
+
+// newRecorder creates a new recorder.
+func newRecorder(
+	clock Clock,
+	tableName string,
+	codeVersion string,
+	codeRevision string,
+) *recorder {
+	return &recorder{
+		clock:        clock,
+		tableName:    tableName,
+		codeVersion:  codeVersion,
+		codeRevision: codeRevision,
+	}
+}
+
+// GetCurrentVersion gets the current migration version, or 0 if no migrations were previously
+// applied.
+func (r *recorder) GetCurrentVersion(ctx context.Context, tx *sql.Tx) (int64, error) {
+	query, err := r.getCurrentVersionQuery()
+	if err != nil {
+		return 0, err
+	}
+
+	row := tx.QueryRowContext(ctx, query)
+
+	var version int64
+	if err := row.Scan(&version); err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return 0, fmt.Errorf("failed to scan current migration version: %w", err)
+	}
+
+	return version, nil
+}
+
+func (r *recorder) getCurrentVersionQuery() (string, error) {
+	switch r.tableName {
+	case tableNameSystem:
+		return systemVersionQuery, nil
+
+	case tableNameUser:
+		return userVersionQuery, nil
+
+	default:
+		return "", fmt.Errorf("internal error: unexpected table name: %s", r.tableName)
+	}
+}
+
+// RecordMigrations records the application of a migration.
+func (r *recorder) RecordMigration(
+	ctx context.Context,
+	tx *sql.Tx,
+	migrationVersion int64,
+	herdVersion int64,
+) error {
+	query, err := r.recordMigrationQuery()
+	if err != nil {
+		return err
+	}
+
+	args, err := r.recordMigrationArgs(migrationVersion, herdVersion)
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.ExecContext(ctx, query, args...)
+	return err
+}
+
+func (r *recorder) recordMigrationQuery() (string, error) {
+	switch r.tableName {
+	case tableNameSystem:
+		return systemRecordQuery, nil
+
+	case tableNameUser:
+		return userRecordQuery, nil
+
+	default:
+		return "", fmt.Errorf("internal error: unexpected table name: %s", r.tableName)
+	}
+}
+
+func (r *recorder) recordMigrationArgs(
+	migrationVersion int64,
+	herdVersion int64,
+) ([]any, error) {
+	now := r.clock.Now().UTC().Truncate(time.Second)
+
+	switch r.tableName {
+	case tableNameSystem:
+		return []any{migrationVersion, now, r.codeVersion, r.codeRevision}, nil
+
+	case tableNameUser:
+		return []any{migrationVersion, now, r.codeVersion, r.codeRevision, herdVersion}, nil
+
+	default:
+		return nil, fmt.Errorf("internal error: unexpected table name: %s", r.tableName)
+	}
+}

--- a/pkg/herd/recorder_test.go
+++ b/pkg/herd/recorder_test.go
@@ -1,0 +1,246 @@
+package herd_test
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattdowdell/sandbox/mocks/domain/mockrepositories"
+	"github.com/mattdowdell/sandbox/pkg/herd"
+)
+
+func Test_newRecorder(t *testing.T) {
+	tests := map[string]struct {
+		table string
+	}{
+		"system": {
+			table: herd.TableNameSystem,
+		},
+		"user": {
+			table: herd.TableNameUser,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			// arrange
+			clock := mockrepositories.NewClock(t)
+
+			// act
+			recorder := herd.NewRecorder(clock, tt.table, testCodeVersion, testCodeRevision)
+
+			// assert
+			assert.NotNil(t, recorder)
+		})
+	}
+}
+
+func Test_recorder_GetCurrentVersion_Success(t *testing.T) {
+	tests := map[string]struct {
+		table string
+		query string
+	}{
+		"system": {
+			table: herd.TableNameSystem,
+			query: herd.SystemVersionQuery,
+		},
+		"user": {
+			table: herd.TableNameUser,
+			query: herd.UserVersionQuery,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			// arrange
+			clock := mockrepositories.NewClock(t)
+			recorder := herd.NewRecorder(clock, tt.table, testCodeVersion, testCodeRevision)
+
+			db, mock := newMockDB(t)
+			mock.ExpectBegin()
+			mock.ExpectQuery(tt.query).WillReturnRows(sqlmock.NewRows(testQueryRows).AddRow(1))
+
+			tx, err := db.BeginTx(t.Context(), &sql.TxOptions{})
+			require.NoError(t, err)
+
+			// act
+			version, err := recorder.GetCurrentVersion(t.Context(), tx)
+
+			// assert
+			assert.Equal(t, int64(1), version)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func Test_recorder_GetCurrentVersion_Error(t *testing.T) {
+	tests := map[string]struct {
+		table string
+		db    func(*testing.T) *sql.DB
+		want  string
+	}{
+		"invalid table": {
+			table: "invalid",
+			db: func(t *testing.T) *sql.DB {
+				t.Helper()
+
+				db, mock := newMockDB(t)
+				mock.ExpectBegin()
+
+				return db
+			},
+			want: "internal error: unexpected table name: invalid",
+		},
+		"query error": {
+			table: herd.TableNameSystem,
+			db: func(t *testing.T) *sql.DB {
+				t.Helper()
+
+				db, mock := newMockDB(t)
+				mock.ExpectBegin()
+				mock.ExpectQuery(herd.SystemVersionQuery).WillReturnError(errors.New("query error"))
+
+				return db
+			},
+			want: "failed to scan current migration version: query error",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(_ *testing.T) {
+			// arrange
+			clock := mockrepositories.NewClock(t)
+			recorder := herd.NewRecorder(clock, tt.table, testCodeVersion, testCodeRevision)
+
+			db := tt.db(t)
+
+			tx, err := db.BeginTx(t.Context(), &sql.TxOptions{})
+			require.NoError(t, err)
+
+			// act
+			version, err := recorder.GetCurrentVersion(t.Context(), tx)
+
+			// assert
+			assert.Zero(t, version)
+			assert.EqualError(t, err, tt.want)
+		})
+	}
+}
+
+func Test_recorder_RecordMigration_Success(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	tests := map[string]struct {
+		table string
+		query string
+		args  []driver.Value
+	}{
+		"system": {
+			table: herd.TableNameSystem,
+			query: herd.SystemRecordQuery,
+			args: []driver.Value{
+				testMigrationVersion,
+				now,
+				testCodeVersion,
+				testCodeRevision,
+			},
+		},
+		"user": {
+			table: herd.TableNameUser,
+			query: herd.UserRecordQuery,
+			args: []driver.Value{
+				testMigrationVersion,
+				now,
+				testCodeVersion,
+				testCodeRevision,
+				testHerdVersion,
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			// arrange
+			clock := mockrepositories.NewClock(t)
+			clock.EXPECT().Now().Return(now).Once()
+
+			recorder := herd.NewRecorder(clock, tt.table, testCodeVersion, testCodeRevision)
+
+			db, mock := newMockDB(t)
+			mock.ExpectBegin()
+			mock.ExpectExec(tt.query).WithArgs(tt.args...).WillReturnResult(driver.ResultNoRows)
+
+			tx, err := db.BeginTx(t.Context(), &sql.TxOptions{})
+			require.NoError(t, err)
+
+			// act
+			err = recorder.RecordMigration(t.Context(), tx, testMigrationVersion, testHerdVersion)
+
+			// assert
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func Test_recorder_RecordMigration_Error(t *testing.T) {
+	tests := map[string]struct {
+		table string
+		db    func(*testing.T) *sql.DB
+		want  string
+	}{
+		"invalid table": {
+			table: "invalid",
+			db: func(t *testing.T) *sql.DB {
+				t.Helper()
+
+				db, mock := newMockDB(t)
+				mock.ExpectBegin()
+
+				return db
+			},
+			want: "internal error: unexpected table name: invalid",
+		},
+		"exec error": {
+			table: herd.TableNameSystem,
+			db: func(t *testing.T) *sql.DB {
+				t.Helper()
+
+				db, mock := newMockDB(t)
+				mock.ExpectBegin()
+				mock.ExpectExec(herd.SystemRecordQuery).WillReturnError(errors.New("exec error"))
+
+				return db
+			},
+			want: "exec error",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(_ *testing.T) {
+			// arrange
+			now := time.Now().UTC().Truncate(time.Second)
+
+			clock := mockrepositories.NewClock(t)
+			clock.EXPECT().Now().Return(now).Maybe()
+
+			recorder := herd.NewRecorder(clock, tt.table, testCodeVersion, testCodeRevision)
+
+			db := tt.db(t)
+
+			tx, err := db.BeginTx(t.Context(), &sql.TxOptions{})
+			require.NoError(t, err)
+
+			// act
+			err = recorder.RecordMigration(t.Context(), tx, testMigrationVersion, testHerdVersion)
+
+			// assert
+			assert.EqualError(t, err, tt.want)
+		})
+	}
+}


### PR DESCRIPTION
Add a migrator implementation to herd that can apply both system and user-defined database migrations. The implementation is internal as it will later be wrapped in a runner that applies both system and user migrations is one call.