### PR TITLE
Add license suppression for tzdata-legacy

### DIFF
--- a/config/trivyignore.rego
+++ b/config/trivyignore.rego
@@ -16,6 +16,11 @@ ignore {
 }
 
 ignore {
+    input.PkgName == "base-files"
+    input.Name == "verbatim"
+}
+
+ignore {
     input.PkgName == "netbase"
     input.Name == "GPL-2.0-only"
 }

--- a/config/trivyignore.rego
+++ b/config/trivyignore.rego
@@ -26,6 +26,11 @@ ignore {
 }
 
 ignore {
+    input.PkgName == "tzdata-legacy"
+    input.Name == "public-domain"
+}
+
+ignore {
     input.PkgName = "media-types"
     input.Name = "ad-hoc"
 }


### PR DESCRIPTION
Distroless based on Debian 13 includes a tzdata-legacy package. This package uses the same public-domain license as tzdata, so should be suppressed in Trivy's reporting the same way.

Also add a new suppression for base-files which Trivy reports as using a "verbatim" license, but seems to be the same GPL 2.0+ as in Debian 12.