### PR TITLE
Update app-id -> client-id

### DIFF
--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -52,7 +52,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.REGENERATE_APP_ID }}
+          client-id: ${{ secrets.REGENERATE_APP_ID }}
           private-key: ${{ secrets.REGENERATE_APP_PEM }}
           permission-contents: write
 


### PR DESCRIPTION
Rename the deprecated `app-id` input on `actions/create-github-app-token` to `client-id`. I think this is a simple rename, but we can test post-merge to be sure.